### PR TITLE
fix(errors): BH-P05, BH-019 — error hygiene

### DIFF
--- a/application_context/associations.go
+++ b/application_context/associations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+	"mahresources/application_context/validation"
 	"mahresources/models"
 )
 
@@ -11,10 +12,29 @@ import (
 // Names longer than this are rejected to prevent database bloat and rendering issues.
 const MaxEntityNameLength = 1000
 
-// ValidateEntityName checks that a name does not exceed MaxEntityNameLength.
+// ValidateEntityName checks that a name is well-formed for the given entity type.
+//
+// A name is rejected if it:
+//   - exceeds MaxEntityNameLength bytes
+//   - contains NUL bytes, C0 controls (except TAB), C1 controls, CR/LF,
+//     or Unicode directional overrides/isolates (BH-019)
+//
+// Empty names are accepted here so that callers preserving backward-compatible
+// "name is optional on update" semantics can continue to do so; callers that
+// require a non-empty name must still check for that themselves (the existing
+// call sites do, and they check before invoking this function).
 func ValidateEntityName(name, entityType string) error {
 	if len(name) > MaxEntityNameLength {
 		return fmt.Errorf("%s name must not exceed %d characters", entityType, MaxEntityNameLength)
+	}
+	// Allow empty names through — the existing "name optional on update"
+	// semantics in some context files rely on that. Non-empty names must
+	// pass the control-character / bidi-override checks.
+	if name == "" {
+		return nil
+	}
+	if _, err := validation.SanitizeEntityName(name); err != nil {
+		return fmt.Errorf("%s %s", entityType, err.Error())
 	}
 	return nil
 }

--- a/application_context/basic_entity_context.go
+++ b/application_context/basic_entity_context.go
@@ -26,6 +26,9 @@ func (w *EntityWriter[T]) UpdateName(id uint, name string) error {
 	if strings.TrimSpace(name) == "" {
 		return errors.New("name must not be empty")
 	}
+	if err := ValidateEntityName(name, "entity"); err != nil {
+		return err
+	}
 	entity := new(T)
 	result := w.ctx.db.Model(entity).Where("id = ?", id).Update("name", name)
 	if result.Error != nil {

--- a/application_context/category_context.go
+++ b/application_context/category_context.go
@@ -104,6 +104,10 @@ func (ctx *MahresourcesContext) CreateCategory(categoryQuery *query_models.Categ
 }
 
 func (ctx *MahresourcesContext) UpdateCategory(categoryQuery *query_models.CategoryEditor) (*models.Category, error) {
+	if err := ValidateEntityName(categoryQuery.Name, "category"); err != nil {
+		return nil, err
+	}
+
 	hookData := map[string]any{
 		"id":          float64(categoryQuery.ID),
 		"name":        categoryQuery.Name,

--- a/application_context/resource_crud_context.go
+++ b/application_context/resource_crud_context.go
@@ -144,6 +144,10 @@ func (ctx *MahresourcesContext) GetResourcesWithIds(ids *[]uint) ([]*models.Reso
 }
 
 func (ctx *MahresourcesContext) EditResource(resourceQuery *query_models.ResourceEditor) (*models.Resource, error) {
+	if err := ValidateEntityName(resourceQuery.Name, "resource"); err != nil {
+		return nil, err
+	}
+
 	hookData := map[string]any{
 		"id":          float64(resourceQuery.ID),
 		"name":        resourceQuery.Name,

--- a/application_context/resource_upload_context.go
+++ b/application_context/resource_upload_context.go
@@ -502,6 +502,10 @@ func (ctx *MahresourcesContext) AddLocalResource(fileName string, resourceQuery 
 }
 
 func (ctx *MahresourcesContext) AddResource(file interfaces.File, fileName string, resourceQuery *query_models.ResourceCreator) (*models.Resource, error) {
+	if err := ValidateEntityName(resourceQuery.Name, "resource"); err != nil {
+		return nil, err
+	}
+
 	hookData := map[string]any{
 		"id":          float64(0),
 		"name":        resourceQuery.Name,

--- a/application_context/tags_context.go
+++ b/application_context/tags_context.go
@@ -103,6 +103,10 @@ func (ctx *MahresourcesContext) CreateTag(tagQuery *query_models.TagCreator) (*m
 }
 
 func (ctx *MahresourcesContext) UpdateTag(tagQuery *query_models.TagCreator) (*models.Tag, error) {
+	if err := ValidateEntityName(tagQuery.Name, "tag"); err != nil {
+		return nil, err
+	}
+
 	hookData := map[string]any{
 		"id":          float64(tagQuery.ID),
 		"name":        tagQuery.Name,

--- a/application_context/validation/entity_name.go
+++ b/application_context/validation/entity_name.go
@@ -1,0 +1,52 @@
+// Package validation holds pure validators for user-supplied entity data.
+//
+// These helpers have no dependencies on the rest of the application_context
+// package, so they can be unit tested in isolation.
+package validation
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SanitizeEntityName validates and trims a user-supplied entity name.
+//
+// It returns an error if the name contains NUL bytes, C0/C1 control
+// characters (except TAB), Unicode directional overrides/isolates, or
+// embedded newlines/carriage returns, or if it is empty after trimming.
+//
+// Background (BH-019): these characters cause UI spoofing (RTL-override
+// disguised filenames), CSV / log-line injection, and C-library truncation
+// (e.g. ffmpeg shelling out to a path containing a NUL byte). The input
+// layer is the right place to reject them.
+//
+// The returned string is the input with leading/trailing ASCII whitespace
+// stripped; otherwise it is byte-identical.
+func SanitizeEntityName(name string) (string, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", fmt.Errorf("name must not be empty")
+	}
+
+	for i, r := range trimmed {
+		switch {
+		case r == 0x00:
+			return "", fmt.Errorf("name contains NUL byte at position %d", i)
+		case r == '\n' || r == '\r':
+			return "", fmt.Errorf("name contains newline at position %d", i)
+		case r == '\t':
+			// TAB is permitted: it shows up in legitimate labels and is
+			// harmless in our rendering pipeline.
+		case r < 0x20 || r == 0x7F:
+			return "", fmt.Errorf("name contains control character U+%04X at position %d", r, i)
+		case r >= 0x80 && r < 0xA0:
+			return "", fmt.Errorf("name contains C1 control character U+%04X at position %d", r, i)
+		case r >= 0x202A && r <= 0x202E:
+			return "", fmt.Errorf("name contains directional override U+%04X at position %d", r, i)
+		case r >= 0x2066 && r <= 0x2069:
+			return "", fmt.Errorf("name contains directional isolate U+%04X at position %d", r, i)
+		}
+	}
+
+	return trimmed, nil
+}

--- a/application_context/validation/entity_name_test.go
+++ b/application_context/validation/entity_name_test.go
@@ -1,0 +1,82 @@
+package validation_test
+
+import (
+	"strings"
+	"testing"
+
+	"mahresources/application_context/validation"
+)
+
+func TestSanitizeEntityName_RejectsNullByte(t *testing.T) {
+	_, err := validation.SanitizeEntityName("foo\x00bar")
+	if err == nil {
+		t.Fatal("expected error for NUL byte, got nil")
+	}
+	if !strings.Contains(err.Error(), "NUL") && !strings.Contains(err.Error(), "control") {
+		t.Fatalf("expected error to mention NUL/control, got: %v", err)
+	}
+}
+
+func TestSanitizeEntityName_RejectsDirectionalOverrides(t *testing.T) {
+	// U+202A..U+202E (embedding + override) and U+2066..U+2069 (isolates)
+	for _, ch := range []string{
+		"‪", "‫", "‬", "‭", "‮",
+		"⁦", "⁧", "⁨", "⁩",
+	} {
+		_, err := validation.SanitizeEntityName("foo" + ch + "bar")
+		if err == nil {
+			t.Fatalf("expected error for directional override U+%04X, got nil", []rune(ch)[0])
+		}
+	}
+}
+
+func TestSanitizeEntityName_RejectsEmbeddedNewlines(t *testing.T) {
+	for _, raw := range []string{"foo\nbar", "foo\rbar", "foo\r\nbar"} {
+		_, err := validation.SanitizeEntityName(raw)
+		if err == nil {
+			t.Fatalf("expected error for embedded newline in %q, got nil", raw)
+		}
+	}
+}
+
+func TestSanitizeEntityName_RejectsC0Controls(t *testing.T) {
+	// A handful of representative C0 control characters other than TAB/CR/LF.
+	for _, r := range []rune{'\x01', '\x07', '\x1B', '\x7F'} {
+		_, err := validation.SanitizeEntityName("foo" + string(r) + "bar")
+		if err == nil {
+			t.Fatalf("expected error for C0 control U+%04X, got nil", r)
+		}
+	}
+}
+
+func TestSanitizeEntityName_AllowsTabAndNormalUnicode(t *testing.T) {
+	cases := []string{"hello world", "café", "日本語", "name\twith\ttab", "emoji \U0001F600"}
+	for _, raw := range cases {
+		got, err := validation.SanitizeEntityName(raw)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", raw, err)
+		}
+		if got != raw {
+			t.Fatalf("expected passthrough for %q, got %q", raw, got)
+		}
+	}
+}
+
+func TestSanitizeEntityName_TrimsSurroundingWhitespace(t *testing.T) {
+	got, err := validation.SanitizeEntityName("  hello  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("expected trimmed 'hello', got %q", got)
+	}
+}
+
+func TestSanitizeEntityName_RejectsEmptyAfterTrim(t *testing.T) {
+	for _, raw := range []string{"", "   ", "\t\t"} {
+		_, err := validation.SanitizeEntityName(raw)
+		if err == nil {
+			t.Fatalf("expected error for whitespace-only name %q, got nil", raw)
+		}
+	}
+}

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c1-error-hygiene.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c1-error-hygiene.md
@@ -1,0 +1,507 @@
+# Cluster 1 — Error Hygiene (BH-P05, BH-019)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Can run 2 parallel subagents (Task groups A and B touch disjoint files). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Stop leaking internal server config on `.json` error paths (BH-P05) and reject control-character/bidi-override/NUL in entity names at the input layer (BH-019).
+
+**Architecture:** Two surgical fixes on disjoint files. Group A extends `discardFields` in `server/template_handlers/render_template.go` to strip `_appContext` and `_requestContext` from JSON error responses. Group B introduces `application_context/validation/entity_name.go` with a shared `SanitizeEntityName` helper called from tag/group/note/resource/noteType/category create+update paths.
+
+**Tech Stack:** Go, pongo2 templates, Gorilla Mux, existing `server/api_tests/` test suite.
+
+**Worktree branch:** `bugfix/c1-error-hygiene`
+
+---
+
+## File structure
+
+**Modified:**
+- `server/template_handlers/render_template.go` — add `_appContext`, `_requestContext` to the existing `discardFields` denylist (BH-P05)
+- `application_context/tag_context.go`, `group_context.go`, `note_context.go`, `resource_context.go`, `note_type_context.go`, `category_context.go` — call `SanitizeEntityName` on create and update (BH-019)
+
+**Created:**
+- `application_context/validation/entity_name.go` — new helper
+- `application_context/validation/entity_name_test.go` — unit tests
+- `server/api_tests/json_error_leaks_appcontext_test.go` — BH-P05 regression
+- `server/api_tests/entity_name_control_chars_test.go` — BH-019 API-level test
+
+---
+
+## Task Group A: BH-P05 — JSON error leak
+
+### Task A1: Write failing test for `_appContext` leak on `.json` error
+
+**Files:**
+- Create: `server/api_tests/json_error_leaks_appcontext_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonErrorDoesNotLeakAppContext(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Non-numeric id triggers an error via .json route
+	resp := tc.MakeRequest(http.MethodGet, "/resource.json?id=abc", nil)
+	assert.GreaterOrEqual(t, resp.Code, 400, "response should be an error status")
+
+	var body map[string]any
+	err := json.Unmarshal(resp.Body.Bytes(), &body)
+	require.NoError(t, err, "response should be valid JSON")
+
+	// These must NOT leak — they exposed DbDsn, FfmpegPath, FileSavePath, AltFileSystems, etc.
+	assert.NotContains(t, body, "_appContext", "_appContext must not leak in JSON error response")
+	assert.NotContains(t, body, "_requestContext", "_requestContext must not leak in JSON error response")
+
+	// Sanity: the user-facing error must still be present
+	assert.Contains(t, body, "errorMessage", "errorMessage should be present in error response")
+}
+
+func TestJsonErrorDoesNotLeakAppContextAcrossEntities(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	for _, path := range []string{"/note.json?id=abc", "/group.json?id=abc", "/tag.json?id=abc", "/resource.json?id=abc"} {
+		resp := tc.MakeRequest(http.MethodGet, path, nil)
+		assert.GreaterOrEqual(t, resp.Code, 400, "%s: expected error status", path)
+
+		var body map[string]any
+		err := json.Unmarshal(resp.Body.Bytes(), &body)
+		require.NoError(t, err, "%s: response should be valid JSON", path)
+
+		assert.NotContains(t, body, "_appContext", "%s: _appContext must not leak", path)
+		assert.NotContains(t, body, "_requestContext", "%s: _requestContext must not leak", path)
+	}
+}
+```
+
+- [ ] **Step 2: Run test 3× to verify it fails consistently with the real symptom**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestJsonErrorDoesNotLeakAppContext -v -count=3
+```
+
+Expected: FAIL all 3 runs. Failure message must mention `_appContext` or `_requestContext` being present in the body — this confirms the symptom matches BH-P05. If failure is for a different reason (compile error, test setup), fix the test itself first.
+
+### Task A2: Add `_appContext` and `_requestContext` to discardFields
+
+**Files:**
+- Modify: `server/template_handlers/render_template.go:54-78`
+
+- [ ] **Step 1: Add the two keys to the existing denylist**
+
+In `render_template.go`, the `discardFields` call in `RenderTemplate`'s JSON branch already discards UI fields. Add `_appContext` and `_requestContext`:
+
+```go
+if err := json.NewEncoder(writer).Encode(discardFields(map[string]bool{
+    // Function-valued fields (cannot serialize to JSON)
+    "partial":     true,
+    "path":        true,
+    "withQuery":   true,
+    "hasQuery":    true,
+    "stringId":    true,
+    "getNextId":   true,
+    "dereference": true,
+    // Internal/rendering fields (should not leak to JSON consumers)
+    "_pluginManager":     true,
+    "_statusCode":        true,
+    "_appContext":        true,  // BH-P05: contains Config (DbDsn, FfmpegPath, etc.)
+    "_requestContext":    true,  // BH-P05: contains nested Go context
+    "currentPath":        true,
+    "pluginMenuItems":    true,
+    "menu":               true,
+    "adminMenu":          true,
+    "title":              true,
+    "assetVersion":       true,
+    "queryValues":        true,
+    "url":                true,
+    "hasPluginManager":   true,
+    "pluginDetailActions": true,
+    "pluginCardActions":  true,
+    "pluginBulkActions":  true,
+}, context)); err != nil {
+    fmt.Println(err)
+}
+```
+
+- [ ] **Step 2: Run the new tests 3× to verify they pass**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestJsonErrorDoesNotLeakAppContext -v -count=3
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 3: Run the full existing `json_route_no_internal_context_test.go` suite to confirm no regression**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run 'TestJsonRouteError|TestJsonRouteSuccess|TestJsonRouteDoesNotLeak|TestJsonErrorDoes' -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd <worktree>
+git add server/template_handlers/render_template.go server/api_tests/json_error_leaks_appcontext_test.go
+git commit -m "fix(errors): BH-P05 — stop leaking _appContext/_requestContext on .json errors"
+```
+
+---
+
+## Task Group B: BH-019 — Entity name control-char sanitization
+
+### Task B1: Write unit test for `SanitizeEntityName` helper
+
+**Files:**
+- Create: `application_context/validation/entity_name_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package validation_test
+
+import (
+	"strings"
+	"testing"
+
+	"mahresources/application_context/validation"
+)
+
+func TestSanitizeEntityName_RejectsNullByte(t *testing.T) {
+	_, err := validation.SanitizeEntityName("foo\x00bar")
+	if err == nil {
+		t.Fatal("expected error for NUL byte, got nil")
+	}
+	if !strings.Contains(err.Error(), "control character") {
+		t.Fatalf("expected 'control character' error, got: %v", err)
+	}
+}
+
+func TestSanitizeEntityName_RejectsDirectionalOverrides(t *testing.T) {
+	for _, ch := range []string{"‪", "‫", "‬", "‭", "‮", "⁦", "⁧", "⁨", "⁩"} {
+		_, err := validation.SanitizeEntityName("foo" + ch + "bar")
+		if err == nil {
+			t.Fatalf("expected error for directional override %U, got nil", []rune(ch)[0])
+		}
+	}
+}
+
+func TestSanitizeEntityName_RejectsEmbeddedNewlines(t *testing.T) {
+	for _, raw := range []string{"foo\nbar", "foo\rbar", "foo\r\nbar"} {
+		_, err := validation.SanitizeEntityName(raw)
+		if err == nil {
+			t.Fatalf("expected error for embedded newline in %q, got nil", raw)
+		}
+	}
+}
+
+func TestSanitizeEntityName_AllowsTabAndNormalUnicode(t *testing.T) {
+	for _, raw := range []string{"hello world", "café", "日本語", "name\twith\ttab", "emoji \U0001F600"} {
+		got, err := validation.SanitizeEntityName(raw)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", raw, err)
+		}
+		if got != raw {
+			t.Fatalf("expected passthrough for %q, got %q", raw, got)
+		}
+	}
+}
+
+func TestSanitizeEntityName_TrimsSurroundingWhitespace(t *testing.T) {
+	got, err := validation.SanitizeEntityName("  hello  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Fatalf("expected trimmed 'hello', got %q", got)
+	}
+}
+
+func TestSanitizeEntityName_RejectsEmptyAfterTrim(t *testing.T) {
+	_, err := validation.SanitizeEntityName("   ")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only name")
+	}
+}
+```
+
+- [ ] **Step 2: Run test 3× to verify it fails with compilation error** (the helper package doesn't exist yet — that's the expected pre-implementation symptom)
+
+```bash
+go test --tags 'json1 fts5' ./application_context/validation/... -v -count=3
+```
+
+Expected: 3× FAIL with "package validation is not in GOROOT" or similar import error. This matches the pre-implementation state.
+
+### Task B2: Implement `SanitizeEntityName` helper
+
+**Files:**
+- Create: `application_context/validation/entity_name.go`
+
+- [ ] **Step 1: Write the implementation**
+
+```go
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// SanitizeEntityName validates and trims a user-supplied entity name.
+// Returns an error if the name contains NUL bytes, C0 controls (except TAB),
+// Unicode directional overrides, embedded newlines/CRs, or is empty after trimming.
+//
+// Context: BH-019 — these characters cause UI spoofing, CSV/log corruption,
+// and C-library truncation (e.g., ffmpeg shelling to paths containing NUL).
+func SanitizeEntityName(name string) (string, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", fmt.Errorf("name must not be empty")
+	}
+
+	for i, r := range trimmed {
+		switch {
+		case r == 0x00:
+			return "", fmt.Errorf("name contains NUL byte at position %d", i)
+		case r == '\n' || r == '\r':
+			return "", fmt.Errorf("name contains newline at position %d", i)
+		case r == '\t':
+			// allowed
+		case r < 0x20 || r == 0x7F:
+			return "", fmt.Errorf("name contains control character U+%04X at position %d", r, i)
+		case r >= 0x80 && r < 0xA0:
+			return "", fmt.Errorf("name contains C1 control character U+%04X at position %d", r, i)
+		case r >= 0x202A && r <= 0x202E:
+			return "", fmt.Errorf("name contains directional override U+%04X at position %d", r, i)
+		case r >= 0x2066 && r <= 0x2069:
+			return "", fmt.Errorf("name contains directional isolate U+%04X at position %d", r, i)
+		case !unicode.IsGraphic(r) && r != '\t':
+			return "", fmt.Errorf("name contains non-graphic character U+%04X at position %d", r, i)
+		}
+	}
+
+	return trimmed, nil
+}
+```
+
+- [ ] **Step 2: Run test 3× to verify it passes**
+
+```bash
+go test --tags 'json1 fts5' ./application_context/validation/... -v -count=3
+```
+
+Expected: PASS all 3 runs.
+
+### Task B3: Wire `SanitizeEntityName` into all entity create + update handlers
+
+**Files (each modified once for create, once for update):**
+- Modify: `application_context/tag_context.go`
+- Modify: `application_context/group_crud_context.go`
+- Modify: `application_context/note_context.go`
+- Modify: `application_context/resource_context.go`
+- Modify: `application_context/note_type_context.go`
+- Modify: `application_context/category_context.go`
+
+- [ ] **Step 1: For each context file above, locate the function that creates the entity (typically `Create<Entity>` or `Add<Entity>`) and the function that updates it (typically `Update<Entity>` or `Edit<Entity>`). At the top of each, before any DB operation, call:**
+
+```go
+cleanName, err := validation.SanitizeEntityName(query.Name)
+if err != nil {
+    return nil, err
+}
+query.Name = cleanName
+```
+
+Add the import `"mahresources/application_context/validation"` to each file.
+
+**Important:** If a context file does not expose `Name` on its query struct (e.g., it re-uses a shared DTO), call `SanitizeEntityName` on whichever field carries the user-facing name for the entity. Refer to the existing whitespace-name validation tests under `server/api_tests/whitespace_name_validation_test.go` for patterns already established.
+
+- [ ] **Step 2: Run existing tests to catch any behavior change on legitimate names**
+
+```bash
+go test --tags 'json1 fts5' ./application_context/... ./server/api_tests/... -v -run 'TestTag|TestGroup|TestNote|TestResource|TestNoteType|TestCategory'
+```
+
+Expected: PASS. If a test breaks because it used a name containing, for example, a newline, update the test to use a legitimate name — the old behavior was the bug.
+
+### Task B4: Write API-level test for BH-019 symptom
+
+**Files:**
+- Create: `server/api_tests/entity_name_control_chars_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-nul\x00byte")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "NUL-byte name must be rejected with 400")
+}
+
+func TestTagCreate_RejectsDirectionalOverrideInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19‮rotated")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "RTL override in name must be rejected")
+}
+
+func TestTagCreate_RejectsEmbeddedNewlineInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19\nwith newline")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "Newline in name must be rejected")
+}
+
+func TestTagCreate_AcceptsNormalName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "ordinary-tag-name")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusOK, resp.Code, "Ordinary name must still succeed")
+}
+
+// Parallel checks for the other entity types.
+func TestGroupCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-group\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/group", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+func TestNoteCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-note\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/note", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+func TestCategoryCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-cat\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/category", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+func TestNoteTypeCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-nt\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/noteType", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+```
+
+- [ ] **Step 2: Run 3× — expect PASS now that Task B3 wired the validation**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run 'TestTagCreate_RejectsNullByte|TestGroupCreate_RejectsNullByte|TestNoteCreate_RejectsNullByte|TestCategoryCreate_RejectsNullByte|TestNoteTypeCreate_RejectsNullByte|TestTagCreate_RejectsDirectional|TestTagCreate_RejectsEmbedded|TestTagCreate_AcceptsNormal' -v -count=3
+```
+
+Expected: PASS all 3 runs. If any endpoint returns 200 for NUL-byte names, Task B3 missed that endpoint — go back and wire it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd <worktree>
+git add application_context/validation/ application_context/*_context.go server/api_tests/entity_name_control_chars_test.go
+git commit -m "fix(validation): BH-019 — reject NUL/bidi/newlines in entity names"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Go unit + API full suite**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Rebase on latest master**
+
+```bash
+git fetch origin
+git rebase origin/master
+```
+
+- [ ] **Step 3: Full E2E browser + CLI + Postgres (per master plan)**
+
+```bash
+cd e2e && npm run test:with-server:all
+cd .. && go test --tags 'json1 fts5 postgres' ./mrql/... ./server/api_tests/... -count=1
+cd e2e && npm run test:with-server:postgres
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "fix(errors): BH-P05, BH-019 — error hygiene" --body "$(cat <<'EOF'
+Closes BH-P05, BH-019.
+
+## Changes
+
+- `server/template_handlers/render_template.go` — add `_appContext` + `_requestContext` to JSON discard list. `.json` error responses no longer leak server config.
+- `application_context/validation/entity_name.go` — new `SanitizeEntityName` helper rejects NUL bytes, C0/C1 controls (except `\t`), Unicode directional overrides (U+202A–U+202E, U+2066–U+2069), and embedded newlines.
+- Wired into tag/group/note/resource/noteType/category create + update paths.
+
+## Tests
+
+- Unit: ✓ `application_context/validation/entity_name_test.go` (6 cases)
+- API: ✓ `server/api_tests/json_error_leaks_appcontext_test.go` (2 cases)
+- API: ✓ `server/api_tests/entity_name_control_chars_test.go` (8 cases)
+- All new tests pass 3× consecutively (both pre-fix 3× red and post-fix 3× green verified)
+- Full `go test ./...`: ✓
+- Full E2E (browser + CLI): ✓
+- Postgres: ✓
+
+## Evidence of fix
+
+- BH-P05: `curl -s http://localhost:8181/resource.json?id=abc | jq 'has("_appContext")'` → `false`
+- BH-019: `POST /v1/tag name=bh-nul%00byte` → HTTP 400
+
+## Bug-hunt-log update
+
+Post-merge, both BH-P05 and BH-019 move from active to fixed in `tasks/bug-hunt-log.md`.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step 5: Update bug-hunt-log and clean up**
+
+Per master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c2-form-ux.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c2-form-ux.md
@@ -1,0 +1,589 @@
+# Cluster 2 — Form-UX Systemic (BH-006, BH-009)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Can run 2 parallel subagents (BH-006 backend PRG vs. BH-009 frontend schema-editor). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Replace native-form-error catastrophes (BH-006 data-loss across all 6 entity create/edit paths) with Post-Redirect-Get + form-value preservation, and surface `required` / `pattern` / `type` validation errors in the schema-editor form mode (BH-009).
+
+**Architecture:** BH-006 — on HTML-accepting POST errors, 302 back to the form URL with the submitted values as query params and an `error=` param; template re-populates fields. JSON 400 path unchanged (API clients). BH-009 — extend `_renderStringInput` / `_renderNumberInput` onBlur handlers to consult `input.validity.{valueMissing,patternMismatch,typeMismatch,tooShort,tooLong,stepMismatch}` and also hook `form.submit` so errors surface on Save.
+
+**Tech Stack:** Go (Gorilla Mux, Pongo2), TypeScript (schema-editor), Playwright E2E.
+
+**Worktree branch:** `bugfix/c2-form-ux`
+
+---
+
+## File structure
+
+**Modified (Group A — BH-006):**
+- `server/http_utils/http_helpers.go` — add `HandleFormError(w, r, redirect, err, form)` helper
+- `server/api_handlers/resource_api_handlers.go` — call helper on create + edit error
+- `server/api_handlers/group_api_handlers.go` — same
+- `server/api_handlers/note_api_handlers.go` — same
+- `server/api_handlers/tag_api_handlers.go` — same
+- `server/api_handlers/category_api_handlers.go` — same (if it has a template form route)
+- `server/api_handlers/handler_factory.go` — if a shared factory wraps all the above, the single change goes there
+- `templates/createResource.tpl`, `createGroup.tpl`, `createNote.tpl`, `createTag.tpl`, `createCategory.tpl`, `editGroup.tpl` (and edit siblings) — read `error` + pre-populate fields from query params
+
+**Modified (Group B — BH-009):**
+- `src/schema-editor/modes/form-mode.ts` — extend onBlur validator, hook submit handler
+- `src/schema-editor/modes/form-mode.test.ts` (or create if not present) — unit tests
+
+**Created:**
+- `e2e/tests/c2-bh006-form-redirects-resource.spec.ts`
+- `e2e/tests/c2-bh006-form-redirects-group.spec.ts`
+- `e2e/tests/c2-bh006-form-redirects-note.spec.ts`
+- `e2e/tests/c2-bh006-form-redirects-category.spec.ts`
+- `e2e/tests/c2-bh006-form-redirects-tag.spec.ts`
+- `e2e/tests/c2-bh006-edit-redirect-group-cycle.spec.ts`
+- `e2e/tests/c2-bh009-schema-editor-required.spec.ts`
+- `e2e/tests/c2-bh009-schema-editor-pattern.spec.ts`
+- `e2e/tests/c2-bh009-schema-editor-type-mismatch.spec.ts`
+
+---
+
+## Pre-work: inventory current handler structure
+
+- [ ] **Step 1: Read the current resource/group/note/tag/category handler patterns**
+
+```bash
+# Use this to identify whether handlers share a factory or are each ad-hoc
+grep -rn "HandleError\|http.Error\|renderError" server/api_handlers/ | head -40
+grep -rn "HandleError" server/http_utils/ | head -10
+cat server/api_handlers/handler_factory.go | head -100
+```
+
+Confirm whether a single helper or six separate edits is the right unit of change. **Record the finding in a brief comment on the PR.**
+
+---
+
+## Task Group A: BH-006 — Form error Post-Redirect-Get
+
+### Task A1: Write the Playwright failing test for resource remote-URL error
+
+**Files:**
+- Create: `e2e/tests/c2-bh006-form-redirects-resource.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test.describe('BH-006: resource form preserves values on server error', () => {
+  test('remote URL 404 keeps user on /resource/new with values + error', async ({ page }) => {
+    await page.goto('/resource/new');
+
+    // Fill with a remote URL that will 404
+    await page.locator('input[name="Name"]').fill('BH006-resource-test');
+    await page.locator('input[name="RemoteUrl"]').fill('https://httpstat.us/404');
+    await page.locator('form button[type="submit"]').click();
+
+    // After submit, URL must still be the create form (not the error page)
+    await expect(page).toHaveURL(/\/resource\/new/);
+
+    // Error message must be visible somewhere on the page
+    await expect(page.locator('body')).toContainText(/error|404|not found/i);
+
+    // Name field value must be preserved — this is the BH-006 symptom
+    await expect(page.locator('input[name="Name"]')).toHaveValue('BH006-resource-test');
+  });
+});
+```
+
+- [ ] **Step 2: Run 3× to verify it fails with the BH-006 symptom**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-006: resource form" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all 3 runs. Failure must be either (a) URL ends up on `/v1/resource` error page, or (b) Name field is empty post-submit. Both match BH-006.
+
+### Task A2: Write Playwright failing tests for the other 4 create forms
+
+**Files:**
+- Create: `c2-bh006-form-redirects-group.spec.ts`, `c2-bh006-form-redirects-note.spec.ts`, `c2-bh006-form-redirects-category.spec.ts`, `c2-bh006-form-redirects-tag.spec.ts`
+
+- [ ] **Step 1: Write each spec using the same pattern**
+
+For group (invalid `OwnerId`):
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-006: group form with invalid OwnerId preserves values', async ({ page }) => {
+  await page.goto('/group/new');
+  await page.locator('input[name="Name"]').fill('BH006-group-test');
+  await page.locator('input[name="OwnerId"]').fill('99999999');
+  await page.locator('form button[type="submit"]').click();
+  await expect(page).toHaveURL(/\/group\/new/);
+  await expect(page.locator('input[name="Name"]')).toHaveValue('BH006-group-test');
+});
+```
+
+For note (invalid `NoteTypeId`):
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-006: note form with invalid NoteTypeId preserves values', async ({ page }) => {
+  await page.goto('/note/new');
+  await page.locator('input[name="Name"]').fill('BH006-note-test');
+  await page.locator('select[name="NoteTypeId"]').selectOption({ index: 0 }).catch(() => {});
+  // Set value directly to bypass the option list
+  await page.evaluate(() => {
+    const el = document.querySelector('select[name="NoteTypeId"], input[name="NoteTypeId"]') as any;
+    if (el) el.value = '99999999';
+  });
+  await page.locator('form button[type="submit"]').click();
+  await expect(page).toHaveURL(/\/note\/new/);
+  await expect(page.locator('input[name="Name"]')).toHaveValue('BH006-note-test');
+});
+```
+
+For category (duplicate name): create one first via API, then try to create again:
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-006: category form with duplicate name preserves values', async ({ page, apiClient }) => {
+  const dupName = `BH006-cat-dup-${Date.now()}`;
+  await apiClient.createCategory({ Name: dupName });
+
+  await page.goto('/category/new');
+  await page.locator('input[name="Name"]').fill(dupName);
+  await page.locator('form button[type="submit"]').click();
+  await expect(page).toHaveURL(/\/category\/new/);
+  await expect(page.locator('input[name="Name"]')).toHaveValue(dupName);
+});
+```
+
+For tag: same pattern, duplicate name.
+
+- [ ] **Step 2: Run all 4 specs 3× in repeat mode to verify they fail**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-006" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all runs for all 4 specs. Each failure must match the BH-006 symptom (URL moves off `/new` OR fields go empty).
+
+### Task A3: Write Playwright failing test for the EDIT path (group ownership cycle)
+
+**Files:**
+- Create: `e2e/tests/c2-bh006-edit-redirect-group-cycle.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-006: group edit that creates cycle preserves form', async ({ page, apiClient }) => {
+  const parent = await apiClient.createGroup({ Name: `BH006-parent-${Date.now()}` });
+  const child = await apiClient.createGroup({ Name: `BH006-child-${Date.now()}`, OwnerId: parent.ID });
+
+  // Try to edit parent to be owned by child — this creates a cycle.
+  await page.goto(`/group/edit?id=${parent.ID}`);
+  await page.locator('input[name="OwnerId"]').fill(String(child.ID));
+  await page.locator('form button[type="submit"]').click();
+
+  // Must remain on the edit form (not bare error page) with the cycle OwnerId preserved
+  await expect(page).toHaveURL(new RegExp(`/group/edit\\?id=${parent.ID}`));
+  await expect(page.locator('body')).toContainText(/cycle/i);
+});
+```
+
+- [ ] **Step 2: Run 3× to verify it fails**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-006: group edit" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all 3 runs.
+
+### Task A4: Implement the `HandleFormError` helper
+
+**Files:**
+- Modify: `server/http_utils/http_helpers.go`
+
+- [ ] **Step 1: Add the helper**
+
+```go
+// HandleFormError writes an appropriate error response for a form submission.
+//
+// For HTML-accepting requests, it 302-redirects to `redirectURL` with the
+// submitted form values preserved as query parameters and an `error` param
+// containing the user-facing message. For JSON-accepting requests, it
+// preserves the existing JSON 400 behavior via HandleError.
+//
+// BH-006 context: native form POST errors previously rendered a bare error
+// page, losing all typed input. This helper keeps users on the form with
+// their data intact.
+func HandleFormError(w http.ResponseWriter, r *http.Request, redirectURL string, err error, form url.Values) {
+    accept := r.Header.Get("Accept")
+    if strings.Contains(accept, constants.JSON) || strings.HasSuffix(r.URL.Path, ".json") {
+        HandleError(w, err)
+        return
+    }
+
+    q := url.Values{}
+    for k, vs := range form {
+        // Never echo sensitive fields back via URL.
+        if k == "Password" || k == "Token" {
+            continue
+        }
+        for _, v := range vs {
+            q.Add(k, v)
+        }
+    }
+    q.Set("error", err.Error())
+
+    sep := "?"
+    if strings.Contains(redirectURL, "?") {
+        sep = "&"
+    }
+    http.Redirect(w, r, redirectURL+sep+q.Encode(), http.StatusFound)
+}
+```
+
+Make sure `url`, `strings`, and `constants` are imported.
+
+- [ ] **Step 2: Run existing tests to verify no regression**
+
+```bash
+go test --tags 'json1 fts5' ./server/http_utils/...
+```
+
+Expected: PASS.
+
+### Task A5: Wire `HandleFormError` into each entity's form handler
+
+**Files to modify (one at a time):**
+- `server/api_handlers/resource_api_handlers.go`
+- `server/api_handlers/group_api_handlers.go`
+- `server/api_handlers/note_api_handlers.go`
+- `server/api_handlers/tag_api_handlers.go`
+- `server/api_handlers/category_api_handlers.go`
+- `server/api_handlers/note_type_api_handlers.go`
+
+- [ ] **Step 1: In each create handler, when the current code calls `http_utils.HandleError(w, err)` after a validation or business-logic failure, replace with `HandleFormError`:**
+
+```go
+if err := r.ParseForm(); err == nil {
+    http_utils.HandleFormError(w, r, "/resource/new", err, r.PostForm)
+    return
+}
+// ... further down, after a business-logic failure:
+if err := appCtx.AddResource(&creator); err != nil {
+    http_utils.HandleFormError(w, r, "/resource/new", err, r.PostForm)
+    return
+}
+```
+
+Adjust the redirect URL per entity: `/resource/new`, `/group/new`, `/note/new`, `/tag/new`, `/category/new`, `/noteType/new`.
+
+- [ ] **Step 2: For each EDIT handler (where applicable), use `?id=<id>` in the redirect URL:**
+
+```go
+// group edit (example)
+redirect := fmt.Sprintf("/group/edit?id=%d", groupID)
+http_utils.HandleFormError(w, r, redirect, err, r.PostForm)
+return
+```
+
+### Task A6: Update create/edit templates to re-populate from query params and display error
+
+**Files to modify (one per entity):**
+- `templates/createResource.tpl` / `editResource.tpl`
+- `templates/createGroup.tpl` / `editGroup.tpl`
+- `templates/createNote.tpl` / `editNote.tpl`
+- `templates/createTag.tpl`
+- `templates/createCategory.tpl`
+- `templates/createNoteType.tpl`
+
+- [ ] **Step 1: At the top of each form template, add an error banner that reads from `queryValues.error.0`:**
+
+```html
+{% if queryValues.error.0 %}
+<div class="form-error-banner" role="alert">
+  <strong>Could not save:</strong> {{ queryValues.error.0 }}
+</div>
+{% endif %}
+```
+
+- [ ] **Step 2: For each `<input>` / `<select>` / `<textarea>` in the form, add a `value="…"` attribute that falls back to the query param value when present:**
+
+```html
+<!-- Example for Name field -->
+<input type="text" name="Name" value="{{ queryValues.Name.0|default:entity.Name }}" required>
+```
+
+The `queryValues.<Field>.0` lookup only resolves when the user was redirected back after an error; on first load it's empty and the `entity.*` fallback works.
+
+- [ ] **Step 3: Run the Playwright specs from Tasks A1–A3 in repeat mode (3×) to verify they pass**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-006" --repeat-each=3 --workers=1
+```
+
+Expected: PASS all 3 runs for each spec.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd <worktree>
+git add server/http_utils/http_helpers.go server/api_handlers/ templates/ e2e/tests/c2-bh006-*.spec.ts
+git commit -m "fix(forms): BH-006 — PRG + preserve form values on server-side errors"
+```
+
+---
+
+## Task Group B: BH-009 — Schema-editor silent validation
+
+### Task B1: Write the failing Playwright test for `required`
+
+**Files:**
+- Create: `e2e/tests/c2-bh009-schema-editor-required.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-009: required field shows inline error on Save without blur', async ({ page, apiClient }) => {
+  // Create a NoteType with a required string field "title".
+  const noteType = await apiClient.createNoteType({
+    Name: `BH009-required-${Date.now()}`,
+    MetaSchema: JSON.stringify({
+      type: 'object',
+      required: ['title'],
+      properties: {
+        title: { type: 'string', minLength: 1 },
+      },
+    }),
+  });
+
+  await page.goto(`/note/new?noteTypeId=${noteType.ID}`);
+
+  // Leave `title` blank, fill the note name, click Save.
+  await page.locator('input[name="Name"]').fill('BH009-note');
+  await page.locator('form button[type="submit"]').click();
+
+  // The error span for the `title` field must show a required message.
+  const errSpan = page.locator('#field-title-error');
+  await expect(errSpan).toBeVisible();
+  await expect(errSpan).toContainText(/required/i);
+
+  // aria-invalid must be true on the offending input.
+  await expect(page.locator('#field-title')).toHaveAttribute('aria-invalid', 'true');
+});
+```
+
+- [ ] **Step 2: Run 3× to verify it fails**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-009: required" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all 3 runs with either "errSpan not visible" or "aria-invalid is null".
+
+### Task B2: Write failing specs for `pattern` and `type mismatch`
+
+**Files:**
+- Create: `e2e/tests/c2-bh009-schema-editor-pattern.spec.ts`
+- Create: `e2e/tests/c2-bh009-schema-editor-type-mismatch.spec.ts`
+
+- [ ] **Step 1: Pattern spec**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-009: pattern violation shows inline error', async ({ page, apiClient }) => {
+  const noteType = await apiClient.createNoteType({
+    Name: `BH009-pattern-${Date.now()}`,
+    MetaSchema: JSON.stringify({
+      type: 'object',
+      properties: {
+        doi: {
+          type: 'string',
+          pattern: '^10\\..*',
+          patternDescription: 'Must start with 10.',
+        },
+      },
+    }),
+  });
+
+  await page.goto(`/note/new?noteTypeId=${noteType.ID}`);
+  await page.locator('input[name="Name"]').fill('BH009-pattern');
+  await page.locator('#field-doi').fill('not a doi');
+  await page.locator('form button[type="submit"]').click();
+
+  const errSpan = page.locator('#field-doi-error');
+  await expect(errSpan).toBeVisible();
+  await expect(errSpan).toContainText(/Must start with 10\.|match/i);
+});
+```
+
+- [ ] **Step 2: Type-mismatch spec** (numeric field with stepMismatch)
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-009: step mismatch shows inline error', async ({ page, apiClient }) => {
+  const noteType = await apiClient.createNoteType({
+    Name: `BH009-step-${Date.now()}`,
+    MetaSchema: JSON.stringify({
+      type: 'object',
+      properties: {
+        rating: { type: 'integer', minimum: 1, maximum: 5 },
+      },
+    }),
+  });
+
+  await page.goto(`/note/new?noteTypeId=${noteType.ID}`);
+  await page.locator('input[name="Name"]').fill('BH009-step');
+  await page.locator('#field-rating').fill('2.5');
+  await page.locator('form button[type="submit"]').click();
+
+  const errSpan = page.locator('#field-rating-error');
+  await expect(errSpan).toBeVisible();
+});
+```
+
+- [ ] **Step 3: Run all 3 BH-009 specs 3× to verify fail**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-009" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all runs.
+
+### Task B3: Extend `_renderStringInput.onBlur` and `_renderNumberInput.onBlur`
+
+**Files:**
+- Modify: `src/schema-editor/modes/form-mode.ts` (around line 1010, per BH-009 citation)
+
+- [ ] **Step 1: Add the additional validity branches**
+
+After the existing min/max branch in `onBlur`, add (TypeScript):
+
+```ts
+if (!error && input.validity.valueMissing) {
+  error = 'This field is required';
+} else if (!error && input.validity.patternMismatch) {
+  error = (schema as any).patternDescription
+    || (schema.pattern ? `Must match the expected format (${schema.pattern})` : 'Invalid format');
+} else if (!error && input.validity.typeMismatch) {
+  error = `Invalid ${inputType} value`;
+} else if (!error && input.validity.tooShort) {
+  error = `Must be at least ${schema.minLength} characters`;
+} else if (!error && input.validity.tooLong) {
+  error = `Must be at most ${schema.maxLength} characters`;
+} else if (!error && input.validity.stepMismatch) {
+  error = 'Value is not a valid step';
+}
+```
+
+Apply symmetrically to `_renderNumberInput.onBlur`.
+
+- [ ] **Step 2: Hook the same logic into form submit**
+
+At the top of `form-mode.ts` where the form is created / bound, add an event listener:
+
+```ts
+form.addEventListener('submit', (ev) => {
+  // Trigger onBlur for each registered input so errors surface even if the user never blurred them.
+  form.querySelectorAll<HTMLInputElement>('input,select,textarea').forEach((el) => {
+    el.dispatchEvent(new FocusEvent('blur'));
+  });
+
+  // If any field has aria-invalid="true" after blur firing, block the submit.
+  const invalid = form.querySelector('[aria-invalid="true"]');
+  if (invalid) {
+    ev.preventDefault();
+    (invalid as HTMLElement).focus();
+  }
+});
+```
+
+- [ ] **Step 3: Rebuild the JS bundle**
+
+```bash
+cd <worktree>
+npm run build-js
+```
+
+- [ ] **Step 4: Run BH-009 specs 3× to verify pass**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-009" --repeat-each=3 --workers=1
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd <worktree>
+git add src/schema-editor/modes/form-mode.ts public/dist e2e/tests/c2-bh009-*.spec.ts
+git commit -m "fix(schema-editor): BH-009 — surface required/pattern/type violations inline"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Go unit + API full suite**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Rebase on latest master**
+
+```bash
+git fetch origin
+git rebase origin/master
+```
+
+- [ ] **Step 3: Full suite per master plan**
+
+Expected: PASS.
+
+- [ ] **Step 4: Open PR, self-merge, update log**
+
+```bash
+gh pr create --title "fix(forms): BH-006, BH-009 — form-UX systemic" --body "$(cat <<'EOF'
+Closes BH-006, BH-009.
+
+## Changes
+
+- `server/http_utils/http_helpers.go` — new `HandleFormError` helper implements Post-Redirect-Get with form-value preservation for HTML-accepting requests; JSON path unchanged.
+- All six entity create + edit handlers (resource, group, note, tag, category, noteType) call the helper on server-side validation failure.
+- Create/edit templates read `queryValues.*` to re-populate fields and show a top-of-form error banner.
+- `src/schema-editor/modes/form-mode.ts` — onBlur now consults `valueMissing`, `patternMismatch`, `typeMismatch`, `tooShort`, `tooLong`, `stepMismatch`. Submit handler dispatches blur on every field first, blocks submit on any `aria-invalid`.
+
+## Tests
+
+- E2E (browser): 6 new specs for BH-006, 3 new specs for BH-009, all pass 3× consecutively pre-fix red / post-fix green.
+- Go unit + API: ✓ full suite.
+- Full E2E (browser + CLI): ✓
+- Postgres: ✓
+
+## Bug-hunt-log update
+
+Post-merge: move BH-006, BH-009 to the Fixed / closed section.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then per master plan Step F — update bug-hunt-log and remove the worktree.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c3-image-hashing.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c3-image-hashing.md
@@ -1,0 +1,480 @@
+# Cluster 3 — Image Ingestion + Hashing (BH-011, BH-018)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. **Serial inside cluster: BH-011 completes before BH-018.** Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Reject truncated / undecodable image uploads at ingestion (BH-011) and eliminate perceptual-hash false positives between solid-color images (BH-018).
+
+**Architecture:** BH-011 — in `application_context/resource_media_context.go`, if `image.Decode` errors or returns `Dx()==0 || Dy()==0`, reject the upload with 400. BH-018 — in `hash_worker/worker.go`'s `findAndStoreSimilarities`, when DHash Hamming ≤ lower-threshold, also require AHash Hamming ≤ a separate threshold before recording the pair. Introduce `--hash-ahash-threshold` flag.
+
+**Tech Stack:** Go, `image` stdlib, `imgsim` library for perceptual hashes.
+
+**Worktree branch:** `bugfix/c3-image-hashing`
+
+---
+
+## File structure
+
+**Modified:**
+- `application_context/resource_media_context.go` — image decode check
+- `application_context/context.go` / config — new `HashAHashThreshold` field, new flag `--hash-ahash-threshold`
+- `hash_worker/worker.go` — AHash check in `findAndStoreSimilarities`
+
+**Created:**
+- `server/api_tests/image_ingestion_rejects_truncated_test.go`
+- `hash_worker/worker_solid_color_test.go`
+
+---
+
+## Pre-work: recon
+
+- [ ] **Step 1: Locate the exact function in `resource_media_context.go` that decodes images**
+
+```bash
+grep -n "image.Decode\|Decode(\|Width\s*=\|Height\s*=" application_context/resource_media_context.go | head -30
+grep -n "DHash\|AHash\|DifferenceHash\|AverageHash\|findAndStoreSimilarities" hash_worker/worker.go | head -40
+```
+
+Expected to find `image.Decode` and the width/height assignment. Note the function name and line — it's where the rejection branch goes.
+
+---
+
+## Task A: BH-011 — Reject truncated images
+
+### Task A1: Write the failing API test
+
+**Files:**
+- Create: `server/api_tests/image_ingestion_rejects_truncated_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Minimal PNG header (8 bytes) without IDAT/IEND — decode must fail.
+// \x89PNG\r\n\x1a\n followed by a fake IHDR chunk that's cut short.
+var truncatedPNG = []byte{
+	0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n',
+	0x00, 0x00, 0x00, 0x0D, 'I', 'H', 'D', 'R',
+	0x00, 0x00, 0x00, 0xc8, 0x00, 0x00, 0x00, 0xc8,
+	0x08, 0x02, 0x00, 0x00, 0x00,
+	// Truncated — no IDAT, no IEND, no trailing CRC table.
+}
+
+func TestImageIngestion_RejectsTruncatedPNG(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("File", "bh011-truncated.png")
+	require.NoError(t, err)
+	_, err = io.Copy(part, bytes.NewReader(truncatedPNG))
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteField("Name", "bh011-truncated"))
+	require.NoError(t, writer.WriteField("ContentType", "image/png"))
+	require.NoError(t, writer.Close())
+
+	req, err := http.NewRequest(http.MethodPost, "/v1/resource", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	tc.Router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code, "truncated image must be rejected with 400")
+	assert.Contains(t, rr.Body.String(), "decode", "error message must reference decode failure")
+}
+
+func TestImageIngestion_AcceptsValidImage(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Valid 1×1 PNG (from stdlib):
+	validPNG := []byte{
+		0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n',
+		0x00, 0x00, 0x00, 0x0D, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+		0x89, 0x00, 0x00, 0x00, 0x0D, 'I', 'D', 'A', 'T',
+		0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05,
+		0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00,
+		0x00, 0x00, 'I', 'E', 'N', 'D', 0xAE, 0x42, 0x60, 0x82,
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, _ := writer.CreateFormFile("File", "bh011-valid.png")
+	io.Copy(part, bytes.NewReader(validPNG))
+	writer.WriteField("Name", "bh011-valid")
+	writer.WriteField("ContentType", "image/png")
+	writer.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, "/v1/resource", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	tc.Router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "valid image must still succeed")
+}
+```
+
+- [ ] **Step 2: Run 3× to verify fail**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestImageIngestion_RejectsTruncatedPNG -v -count=3
+```
+
+Expected: FAIL all 3 runs. Failure: `rr.Code` is `200` (the bug: truncated accepted).
+
+### Task A2: Add the decode-reject branch
+
+**Files:**
+- Modify: `application_context/resource_media_context.go`
+
+- [ ] **Step 1: Locate the image-ingestion entry point (likely a function named `extractImageDimensions`, `processImageUpload`, `populateResourceMeta`, or similar). Wrap the `image.Decode` call:**
+
+```go
+img, _, err := image.Decode(bytes.NewReader(fileBytes))
+if err != nil {
+    return fmt.Errorf("uploaded file is not a valid image (failed to decode): %w", err)
+}
+bounds := img.Bounds()
+if bounds.Dx() == 0 || bounds.Dy() == 0 {
+    return fmt.Errorf("uploaded file is not a valid image (zero dimensions)")
+}
+resource.Width = uint(bounds.Dx())
+resource.Height = uint(bounds.Dy())
+```
+
+Adjust the surrounding function signature to thread the error back up to the HTTP handler so it becomes a 400.
+
+**If the current code silently sets W=0/H=0 and continues, this is the exact behavior BH-011 reports. The fix is to return the error instead.**
+
+- [ ] **Step 2: Ensure the HTTP handler maps this to 400**
+
+Check `server/api_handlers/resource_api_handlers.go` — if `AddResource` (or whatever the create path calls) returns an error, it must surface via `HandleError` with a 400 status code. If the handler currently catches all errors as 500, wrap the decode error in something that maps to 400 (either a sentinel error type or check `strings.Contains(err.Error(), "decode")`).
+
+- [ ] **Step 3: Run the API tests 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestImageIngestion -v -count=3
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 4: Run related resource tests to confirm no regression**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run 'TestResource|TestImage' -v
+```
+
+Expected: PASS. If an existing test relied on accepting zero-dim images, update it to use valid imagery.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd <worktree>
+git add application_context/resource_media_context.go server/api_tests/image_ingestion_rejects_truncated_test.go
+git commit -m "fix(image): BH-011 — reject undecodable / zero-dimension image uploads"
+```
+
+---
+
+## Task B: BH-018 — AHash secondary check for solid-color false positives
+
+### Task B1: Add the config flag
+
+**Files:**
+- Modify: `application_context/context.go` (or wherever `MahresourcesConfig` is defined)
+- Modify: `main.go` (flag registration)
+
+- [ ] **Step 1: Add field + flag**
+
+Config struct:
+
+```go
+type MahresourcesConfig struct {
+    // ...existing fields...
+    HashAHashThreshold uint64 // BH-018: max Hamming distance for AHash secondary check
+}
+```
+
+main.go (command-line flag registration):
+
+```go
+flag.Uint64Var(&config.HashAHashThreshold, "hash-ahash-threshold", 5,
+    "Max Hamming distance for AHash secondary check to confirm DHash similarity (BH-018)")
+```
+
+And the env-var counterpart via the existing env-loader pattern:
+
+```go
+if v := os.Getenv("HASH_AHASH_THRESHOLD"); v != "" {
+    if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+        config.HashAHashThreshold = n
+    }
+}
+```
+
+### Task B2: Write the failing hash-worker unit test
+
+**Files:**
+- Create: `hash_worker/worker_solid_color_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package hash_worker_test
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+
+	"github.com/Nr90/imgsim"
+)
+
+// Reproduce BH-018: AHash distinguishes solid colors; DHash does not.
+// This test asserts that any new similarity predicate (combining DHash + AHash)
+// returns FALSE for two different solid colors.
+func TestSolidColorHashes_AHashDistinguishes(t *testing.T) {
+	lightblue := makeSolidPNG(t, color.RGBA{R: 173, G: 216, B: 230, A: 255})
+	orange := makeSolidPNG(t, color.RGBA{R: 255, G: 165, B: 0, A: 255})
+
+	dhashA := imgsim.DifferenceHash(decodePNG(t, lightblue))
+	dhashB := imgsim.DifferenceHash(decodePNG(t, orange))
+	ahashA := imgsim.AverageHash(decodePNG(t, lightblue))
+	ahashB := imgsim.AverageHash(decodePNG(t, orange))
+
+	// Confirm the DHash false-positive (both zero)
+	if imgsim.Distance(dhashA, dhashB) > 2 {
+		t.Fatalf("pre-condition failed: DHash was expected to be near-zero for solid colors, got distance %d",
+			imgsim.Distance(dhashA, dhashB))
+	}
+
+	// AHash must produce a non-trivial distance
+	ahashDist := imgsim.Distance(ahashA, ahashB)
+	if ahashDist < 10 {
+		t.Fatalf("AHash should distinguish solid lightblue from solid orange, got distance %d", ahashDist)
+	}
+
+	t.Logf("DHash distance: %d, AHash distance: %d", imgsim.Distance(dhashA, dhashB), ahashDist)
+}
+
+func makeSolidPNG(t *testing.T, c color.Color) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, 300, 300))
+	for y := 0; y < 300; y++ {
+		for x := 0; x < 300; x++ {
+			img.Set(x, y, c)
+		}
+	}
+	buf := &bytes.Buffer{}
+	if err := png.Encode(buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func decodePNG(t *testing.T, data []byte) image.Image {
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return img
+}
+```
+
+- [ ] **Step 2: Run 3× — the invariants should PASS on baseline (this is the baseline for BH-018)**
+
+```bash
+go test --tags 'json1 fts5' ./hash_worker/ -run TestSolidColorHashes -v -count=3
+```
+
+Expected: PASS (the precondition). This test documents the hashing invariant. Next test below asserts the actual behavior change.
+
+### Task B3: Write the failing end-to-end similarity test
+
+**Files:**
+- Append to: `hash_worker/worker_solid_color_test.go`
+
+- [ ] **Step 1: Write the failing test using a test-specific similarity helper**
+
+```go
+func TestSimilarity_SolidColorsMustNotMatch(t *testing.T) {
+	lightblueImg := decodePNG(t, makeSolidPNG(t, color.RGBA{173, 216, 230, 255}))
+	orangeImg := decodePNG(t, makeSolidPNG(t, color.RGBA{255, 165, 0, 255}))
+
+	dA, aA := imgsim.DifferenceHash(lightblueImg), imgsim.AverageHash(lightblueImg)
+	dB, aB := imgsim.DifferenceHash(orangeImg), imgsim.AverageHash(orangeImg)
+
+	dhashThr := uint64(10) // matches HashSimilarityThreshold default
+	ahashThr := uint64(5)  // new BH-018 threshold
+
+	similar := hash_worker.AreSimilar(dA, aA, dB, aB, dhashThr, ahashThr)
+	if similar {
+		t.Fatalf("BH-018: lightblue and orange solid PNGs must NOT be recorded as similar")
+	}
+}
+
+func TestSimilarity_NearDupesStillMatch(t *testing.T) {
+	base := makeGradientPNG(t, 0)
+	near := makeGradientPNG(t, 3) // tiny perturbation
+
+	dA, aA := imgsim.DifferenceHash(decodePNG(t, base)), imgsim.AverageHash(decodePNG(t, base))
+	dB, aB := imgsim.DifferenceHash(decodePNG(t, near)), imgsim.AverageHash(decodePNG(t, near))
+
+	similar := hash_worker.AreSimilar(dA, aA, dB, aB, 10, 5)
+	if !similar {
+		t.Fatalf("near-duplicate gradients must still register as similar after BH-018 fix")
+	}
+}
+
+func makeGradientPNG(t *testing.T, offset int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, 300, 300))
+	for y := 0; y < 300; y++ {
+		for x := 0; x < 300; x++ {
+			r := uint8(x + offset)
+			g := uint8(y + offset)
+			img.Set(x, y, color.RGBA{r, g, 128, 255})
+		}
+	}
+	buf := &bytes.Buffer{}
+	png.Encode(buf, img)
+	return buf.Bytes()
+}
+```
+
+Add import `"mahresources/hash_worker"`.
+
+- [ ] **Step 2: Run 3× — expect compile failure because `hash_worker.AreSimilar` does not yet exist**
+
+```bash
+go test --tags 'json1 fts5' ./hash_worker/ -run TestSimilarity -v -count=3
+```
+
+Expected: 3× compile errors about `AreSimilar` undefined — this confirms the pre-implementation state.
+
+### Task B4: Implement `AreSimilar` and use it in `findAndStoreSimilarities`
+
+**Files:**
+- Modify: `hash_worker/worker.go`
+
+- [ ] **Step 1: Export a pure-logic `AreSimilar` helper and use it from `findAndStoreSimilarities`**
+
+```go
+// AreSimilar returns true when two images should be recorded as perceptually
+// similar. BH-018: DHash alone falsely matches all uniform/solid-color images
+// (Hamming distance 0 for every pair). When DHash distance is small, we
+// additionally require AHash distance to be small.
+func AreSimilar(dHashA, aHashA, dHashB, aHashB, dHashThr, aHashThr uint64) bool {
+    dDist := uint64(imgsim.Distance(imgsim.Hash(dHashA), imgsim.Hash(dHashB)))
+    if dDist > dHashThr {
+        return false
+    }
+    aDist := uint64(imgsim.Distance(imgsim.Hash(aHashA), imgsim.Hash(aHashB)))
+    return aDist <= aHashThr
+}
+```
+
+(If `imgsim.Distance` takes native `uint64` directly rather than a Hash struct, adjust accordingly — check the imgsim version already in use.)
+
+- [ ] **Step 2: Update `findAndStoreSimilarities` (around line 423 / 431 per bug log) to consult both DHash and AHash**
+
+Pass AHash into the function signature and use it:
+
+```go
+// Previously: findAndStoreSimilarities(resource.ID, dHashInt)
+findAndStoreSimilarities(resource.ID, dHashInt, aHashInt)
+```
+
+Inside the function, for each candidate row in `image_hashes`:
+
+```go
+if !AreSimilar(candidate.DHashInt, candidate.AHashInt, dHashInt, aHashInt,
+    cfg.HashSimilarityThreshold, cfg.HashAHashThreshold) {
+    continue
+}
+// ... existing insertion logic
+```
+
+- [ ] **Step 3: Run the unit tests 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./hash_worker/ -run TestSimilarity -v -count=3
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd <worktree>
+git add hash_worker/ application_context/context.go main.go
+git commit -m "fix(hash): BH-018 — AHash secondary check eliminates solid-color false positives"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Full Go suite**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Rebase + full E2E + Postgres per master plan.**
+
+- [ ] **Step 3: Open PR, self-merge**
+
+```bash
+gh pr create --title "fix(image): BH-011, BH-018 — ingestion + perceptual-hash correctness" --body "$(cat <<'EOF'
+Closes BH-011, BH-018.
+
+## Changes
+
+- `application_context/resource_media_context.go` — reject uploads where `image.Decode` errors or bounds are zero. 400 with "failed to decode" message.
+- `hash_worker/worker.go` — new `AreSimilar` helper combines DHash (existing) with a secondary AHash check. `findAndStoreSimilarities` now requires both distances below threshold before recording a pair.
+- New flag `--hash-ahash-threshold` (default 5) / env `HASH_AHASH_THRESHOLD`.
+
+## Tests
+
+- Go API: ✓ truncated PNG → 400, valid PNG → 200, pass 3× pre-fix red / post-fix green.
+- Go unit: ✓ two solid colors NOT recorded as similar; two near-dupe gradients still recorded.
+- Full `go test ./...`: ✓
+- Full E2E (browser + CLI): ✓
+- Postgres: ✓
+
+## Operator note
+
+Existing DB rows with `Width=0 AND ContentType LIKE 'image/%'` were created before this fix. Audit query to list them for manual remediation:
+
+```sql
+SELECT id, name, content_type, size FROM resources WHERE content_type LIKE 'image/%' AND (width = 0 OR height = 0);
+```
+
+## Bug-hunt-log update
+
+Post-merge: move BH-011, BH-018 to Fixed / closed.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c4-deletion-cascade.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c4-deletion-cascade.md
@@ -1,0 +1,868 @@
+# Cluster 4 — Block-Content Deletion Cascade (BH-020, BH-024)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Solo subagent (all edits in deletion surface). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** When a resource / group / saved-query is deleted, scrub references to it from `note_blocks.content` (BH-020, systemic across 4 block types). Also fix BH-024: dangling query reference currently returns 500, should be 404.
+
+**Architecture:** Each DELETE handler (resource, group, saved-query) walks `note_blocks` and scrubs matching IDs from the JSON content using DB-native JSON functions (SQLite `json_remove` / `json_set`, Postgres `jsonb_set` with `jsonb_array_elements`). A one-shot migration scrubs pre-existing orphans on boot, gated behind `SKIP_BLOCK_REF_CLEANUP=1`. UI components gain graceful-degrade rendering for unavailable targets. BH-024 receives a 2-line fix: wrap the inner query-fetch with `statusCodeForError`.
+
+**Tech Stack:** Go, GORM with SQLite JSON1 + Postgres JSONB, Alpine.js components.
+
+**Worktree branch:** `bugfix/c4-deletion-cascade`
+
+---
+
+## File structure
+
+**Modified:**
+- `application_context/resource_context.go` — delete handler scrubs `resourceIds[]` and `calendars[].source.resourceId`
+- `application_context/group_crud_context.go` — delete handler scrubs `groupIds[]`
+- `application_context/mrql_context.go` (or wherever `SavedMRQLQuery` is deleted) — scrubs `queryId`
+- `application_context/context.go` — boot-time migration runner, new `SKIP_BLOCK_REF_CLEANUP` flag
+- `server/api_handlers/block_api_handlers.go` — BH-024: wrap inner query fetch with `statusCodeForError`
+- `src/components/blocks/gallery.js` or equivalent — graceful-degrade on resource 404
+- `src/components/blocks/references.js` — graceful-degrade on group 404
+- `src/components/blocks/table.js` or equivalent — graceful-degrade on query 404
+
+**Created:**
+- `application_context/block_ref_cleanup.go` — shared scrubber logic
+- `application_context/block_ref_cleanup_test.go` — unit tests
+- `server/api_tests/block_ref_cascade_test.go` — API-level integration tests (one per block type)
+- `server/api_tests/table_block_dangling_query_returns_404_test.go` — BH-024
+
+---
+
+## Pre-work: confirm block-content schema
+
+- [ ] **Step 1: Read the current block-content shapes**
+
+```bash
+grep -rn "resourceIds\|groupIds\|queryId\|calendars.*source" models/ application_context/block_context.go | head -40
+```
+
+Confirm which fields hold IDs in which block types. BH-020 lists:
+
+- `gallery` → `content.resourceIds[]`
+- `references` → `content.groupIds[]`
+- `calendar` → `content.calendars[].source.resourceId` (type=resource)
+- `table` → `content.queryId`
+
+Adjust field names if they differ in the code from the bug-log descriptions.
+
+---
+
+## Task 1: Failing integration test for gallery-block dangling resource
+
+**Files:**
+- Create: `server/api_tests/block_ref_cascade_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceDelete_ScrubsGalleryBlockReferences(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Create a resource + a note with a gallery block referencing it
+	res := tc.CreateDummyResource(t, "bh020-res")
+	note := tc.CreateDummyNote("bh020-note")
+
+	// Add a gallery block with content.resourceIds = [resID]
+	blockContent := fmt.Sprintf(`{"resourceIds":[%d]}`, res.ID)
+	form := url.Values{}
+	form.Set("NoteId", fmt.Sprintf("%d", note.ID))
+	form.Set("Type", "gallery")
+	form.Set("Content", blockContent)
+	rr := tc.MakeFormRequest(http.MethodPost, "/v1/note/block", form)
+	require.Equal(t, http.StatusOK, rr.Code, "gallery block create failed: %s", rr.Body.String())
+
+	// Delete the resource
+	delRR := tc.MakeRequest(http.MethodDelete, fmt.Sprintf("/v1/resource?id=%d", res.ID), nil)
+	require.Equal(t, http.StatusOK, delRR.Code)
+
+	// Fetch the block and verify resourceIds no longer contains the deleted ID
+	blocksRR := tc.MakeRequest(http.MethodGet, fmt.Sprintf("/v1/note/blocks?noteId=%d", note.ID), nil)
+	require.Equal(t, http.StatusOK, blocksRR.Code)
+
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(blocksRR.Body.Bytes(), &blocks))
+	require.NotEmpty(t, blocks)
+
+	content, ok := blocks[0]["Content"].(map[string]any)
+	require.True(t, ok, "block content must be a JSON object")
+
+	ids, _ := content["resourceIds"].([]any)
+	for _, id := range ids {
+		assert.NotEqual(t, float64(res.ID), id, "deleted resource ID must not remain in gallery.resourceIds")
+	}
+}
+
+func TestGroupDelete_ScrubsReferencesBlockGroupIds(t *testing.T) {
+	tc := SetupTestEnv(t)
+	grp := tc.CreateDummyGroup("bh020-grp")
+	note := tc.CreateDummyNote("bh020-refnote")
+
+	blockContent := fmt.Sprintf(`{"groupIds":[%d]}`, grp.ID)
+	form := url.Values{}
+	form.Set("NoteId", fmt.Sprintf("%d", note.ID))
+	form.Set("Type", "references")
+	form.Set("Content", blockContent)
+	rr := tc.MakeFormRequest(http.MethodPost, "/v1/note/block", form)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	delRR := tc.MakeRequest(http.MethodDelete, fmt.Sprintf("/v1/group?id=%d", grp.ID), nil)
+	require.Equal(t, http.StatusOK, delRR.Code)
+
+	blocksRR := tc.MakeRequest(http.MethodGet, fmt.Sprintf("/v1/note/blocks?noteId=%d", note.ID), nil)
+	var blocks []map[string]any
+	json.Unmarshal(blocksRR.Body.Bytes(), &blocks)
+	require.NotEmpty(t, blocks)
+
+	content, _ := blocks[0]["Content"].(map[string]any)
+	ids, _ := content["groupIds"].([]any)
+	for _, id := range ids {
+		assert.NotEqual(t, float64(grp.ID), id, "deleted group ID must not remain in references.groupIds")
+	}
+}
+
+func TestCalendarBlock_ScrubsResourceSourceOnResourceDelete(t *testing.T) {
+	tc := SetupTestEnv(t)
+	res := tc.CreateDummyResource(t, "bh020-calres")
+	note := tc.CreateDummyNote("bh020-calnote")
+
+	blockContent := fmt.Sprintf(`{"calendars":[{"name":"cal1","source":{"type":"resource","resourceId":%d}}]}`, res.ID)
+	form := url.Values{}
+	form.Set("NoteId", fmt.Sprintf("%d", note.ID))
+	form.Set("Type", "calendar")
+	form.Set("Content", blockContent)
+	rr := tc.MakeFormRequest(http.MethodPost, "/v1/note/block", form)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	delRR := tc.MakeRequest(http.MethodDelete, fmt.Sprintf("/v1/resource?id=%d", res.ID), nil)
+	require.Equal(t, http.StatusOK, delRR.Code)
+
+	blocksRR := tc.MakeRequest(http.MethodGet, fmt.Sprintf("/v1/note/blocks?noteId=%d", note.ID), nil)
+	var blocks []map[string]any
+	json.Unmarshal(blocksRR.Body.Bytes(), &blocks)
+	require.NotEmpty(t, blocks)
+
+	content, _ := blocks[0]["Content"].(map[string]any)
+	cals, _ := content["calendars"].([]any)
+	require.NotEmpty(t, cals)
+	cal0 := cals[0].(map[string]any)
+	source := cal0["source"].(map[string]any)
+	// Either the whole calendar entry is removed, or its source.resourceId is cleared to 0/null.
+	if rid, ok := source["resourceId"]; ok {
+		switch v := rid.(type) {
+		case float64:
+			assert.NotEqual(t, float64(res.ID), v, "calendar source resourceId must be scrubbed")
+		}
+	}
+}
+```
+
+Add a helper `CreateDummyResource` to `api_test_utils.go` if not present:
+
+```go
+func (tc *TestContext) CreateDummyResource(t *testing.T, name string) *models.Resource {
+    r := &models.Resource{Name: name, ContentType: "application/octet-stream", Size: 1}
+    require.NoError(t, tc.DB.Create(r).Error)
+    return r
+}
+```
+
+- [ ] **Step 2: Run 3× — expect fail with the dangling-ID symptom**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestResourceDelete_ScrubsGallery -v -count=3
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestGroupDelete_ScrubsReferences -v -count=3
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestCalendarBlock_ScrubsResource -v -count=3
+```
+
+Expected: 3× FAIL for each, with assertion messages showing the deleted ID still in the block content.
+
+---
+
+## Task 2: Implement the scrubber helpers
+
+**Files:**
+- Create: `application_context/block_ref_cleanup.go`
+
+- [ ] **Step 1: Write the shared scrubber**
+
+```go
+package application_context
+
+import (
+    "fmt"
+
+    "gorm.io/gorm"
+)
+
+// ScrubResourceFromBlocks removes resourceID from every gallery.resourceIds[]
+// and every calendar.calendars[].source.resourceId in the note_blocks table.
+//
+// Called synchronously from the resource DELETE handler, BH-020.
+func ScrubResourceFromBlocks(db *gorm.DB, resourceID uint) error {
+    // Gallery blocks: content.resourceIds is a JSON array of numbers.
+    // SQLite: use json_each + recreate array excluding the deleted ID.
+    // Postgres: jsonb_set with jsonb_array_elements filter.
+    //
+    // To keep logic portable, read each candidate row, mutate in Go, write back.
+    // Volume is bounded by blocks referencing this resource, which is small.
+
+    var blocks []struct {
+        ID      uint
+        Content string
+    }
+    if err := db.Raw(
+        `SELECT id, CAST(content AS TEXT) AS content FROM note_blocks
+         WHERE type IN ('gallery','calendar')`,
+    ).Scan(&blocks).Error; err != nil {
+        return err
+    }
+
+    for _, b := range blocks {
+        updated, changed, err := scrubResourceFromBlockContent(b.Content, resourceID)
+        if err != nil {
+            return fmt.Errorf("block %d: %w", b.ID, err)
+        }
+        if !changed {
+            continue
+        }
+        if err := db.Exec(
+            `UPDATE note_blocks SET content = ? WHERE id = ?`, updated, b.ID,
+        ).Error; err != nil {
+            return err
+        }
+    }
+
+    return nil
+}
+
+// ScrubGroupFromBlocks removes groupID from references.groupIds[].
+func ScrubGroupFromBlocks(db *gorm.DB, groupID uint) error {
+    var blocks []struct {
+        ID      uint
+        Content string
+    }
+    if err := db.Raw(
+        `SELECT id, CAST(content AS TEXT) AS content FROM note_blocks WHERE type = 'references'`,
+    ).Scan(&blocks).Error; err != nil {
+        return err
+    }
+
+    for _, b := range blocks {
+        updated, changed, err := scrubGroupFromBlockContent(b.Content, groupID)
+        if err != nil {
+            return err
+        }
+        if !changed {
+            continue
+        }
+        if err := db.Exec(
+            `UPDATE note_blocks SET content = ? WHERE id = ?`, updated, b.ID,
+        ).Error; err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+// ScrubQueryFromBlocks nulls queryId in every table-block whose queryId matches.
+func ScrubQueryFromBlocks(db *gorm.DB, queryID uint) error {
+    var blocks []struct {
+        ID      uint
+        Content string
+    }
+    if err := db.Raw(
+        `SELECT id, CAST(content AS TEXT) AS content FROM note_blocks WHERE type = 'table'`,
+    ).Scan(&blocks).Error; err != nil {
+        return err
+    }
+    for _, b := range blocks {
+        updated, changed, err := scrubQueryFromBlockContent(b.Content, queryID)
+        if err != nil {
+            return err
+        }
+        if !changed {
+            continue
+        }
+        if err := db.Exec(
+            `UPDATE note_blocks SET content = ? WHERE id = ?`, updated, b.ID,
+        ).Error; err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+Include these pure JSON-mutation helpers in the same file:
+
+```go
+// Returns the updated JSON string, whether anything changed, and any error.
+func scrubResourceFromBlockContent(content string, resourceID uint) (string, bool, error) {
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(content), &raw); err != nil {
+        return content, false, err
+    }
+    changed := false
+
+    // Gallery: content.resourceIds = [id, id, ...]
+    if ids, ok := raw["resourceIds"].([]any); ok {
+        filtered := make([]any, 0, len(ids))
+        for _, v := range ids {
+            if toUint(v) != resourceID {
+                filtered = append(filtered, v)
+            } else {
+                changed = true
+            }
+        }
+        if changed {
+            raw["resourceIds"] = filtered
+        }
+    }
+
+    // Calendar: content.calendars[].source.resourceId
+    if cals, ok := raw["calendars"].([]any); ok {
+        for i, c := range cals {
+            cmap, ok := c.(map[string]any)
+            if !ok {
+                continue
+            }
+            source, ok := cmap["source"].(map[string]any)
+            if !ok {
+                continue
+            }
+            if rid, ok := source["resourceId"]; ok && toUint(rid) == resourceID {
+                delete(source, "resourceId")
+                cmap["source"] = source
+                cals[i] = cmap
+                changed = true
+            }
+        }
+        if changed {
+            raw["calendars"] = cals
+        }
+    }
+
+    if !changed {
+        return content, false, nil
+    }
+    out, err := json.Marshal(raw)
+    if err != nil {
+        return content, false, err
+    }
+    return string(out), true, nil
+}
+
+func scrubGroupFromBlockContent(content string, groupID uint) (string, bool, error) {
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(content), &raw); err != nil {
+        return content, false, err
+    }
+    ids, ok := raw["groupIds"].([]any)
+    if !ok {
+        return content, false, nil
+    }
+    filtered := make([]any, 0, len(ids))
+    changed := false
+    for _, v := range ids {
+        if toUint(v) != groupID {
+            filtered = append(filtered, v)
+        } else {
+            changed = true
+        }
+    }
+    if !changed {
+        return content, false, nil
+    }
+    raw["groupIds"] = filtered
+    out, err := json.Marshal(raw)
+    if err != nil {
+        return content, false, err
+    }
+    return string(out), true, nil
+}
+
+func scrubQueryFromBlockContent(content string, queryID uint) (string, bool, error) {
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(content), &raw); err != nil {
+        return content, false, err
+    }
+    if qid, ok := raw["queryId"]; ok && toUint(qid) == queryID {
+        delete(raw, "queryId")
+        out, err := json.Marshal(raw)
+        if err != nil {
+            return content, false, err
+        }
+        return string(out), true, nil
+    }
+    return content, false, nil
+}
+
+// toUint converts a JSON-decoded number or string to uint; returns 0 if not convertible.
+func toUint(v any) uint {
+    switch x := v.(type) {
+    case float64:
+        return uint(x)
+    case int:
+        return uint(x)
+    case uint:
+        return x
+    case json.Number:
+        n, _ := x.Int64()
+        return uint(n)
+    case string:
+        // best-effort — not expected for these fields, but safe
+        var n uint
+        fmt.Sscanf(x, "%d", &n)
+        return n
+    }
+    return 0
+}
+```
+
+Add the required imports: `"encoding/json"`, `"fmt"`.
+
+- [ ] **Step 2: Add unit tests for the pure-JSON mutators**
+
+**Files:** Create `application_context/block_ref_cleanup_test.go`. Test:
+
+- `scrubResourceFromBlockContent("""{"resourceIds":[1,2,3]}""", 2)` → `{"resourceIds":[1,3]}`, changed=true
+- `scrubResourceFromBlockContent("""{"resourceIds":[1,3]}""", 2)` → changed=false
+- `scrubResourceFromBlockContent("""{"calendars":[{"source":{"resourceId":5}}]}""", 5)` → calendar entry removed or source zeroed, changed=true
+- `scrubGroupFromBlockContent(...)`, `scrubQueryFromBlockContent(...)` — analogous.
+
+Each test follows the standard Go table-test pattern. Run 3× to verify pre-implementation compile failure, then post-implementation pass.
+
+## Task 3: Wire scrubbers into delete handlers
+
+**Files:**
+- Modify: `application_context/resource_context.go` — in the function that deletes a resource, after the resource row is deleted (or before, inside the same transaction), call `ScrubResourceFromBlocks(db, resourceID)`.
+- Modify: `application_context/group_crud_context.go` — same for groups.
+- Modify: `application_context/mrql_context.go` — same for saved queries (find the `DeleteSavedQuery` or similar function).
+
+- [ ] **Step 1: Example wiring (resource)**
+
+```go
+func (ctx *MahresourcesContext) DeleteResource(id uint) error {
+    return ctx.DB.Transaction(func(tx *gorm.DB) error {
+        if err := tx.Delete(&models.Resource{}, id).Error; err != nil {
+            return err
+        }
+        return ScrubResourceFromBlocks(tx, id)
+    })
+}
+```
+
+Do the same for group and saved-query delete.
+
+- [ ] **Step 2: Run the Task 1 integration tests 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run 'TestResourceDelete_ScrubsGallery|TestGroupDelete_ScrubsReferences|TestCalendarBlock_ScrubsResource' -v -count=3
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application_context/block_ref_cleanup*.go application_context/resource_context.go application_context/group_crud_context.go application_context/mrql_context.go server/api_tests/block_ref_cascade_test.go
+git commit -m "fix(blocks): BH-020 — scrub dangling refs on entity delete (gallery/refs/calendar/table)"
+```
+
+## Task 4: One-shot boot-time migration
+
+**Files:**
+- Modify: `application_context/context.go` — in `NewMahresourcesContext` init path, after AutoMigrate, call a new `migrateBlockReferencesOnce(db)` guarded by `SKIP_BLOCK_REF_CLEANUP`.
+
+- [ ] **Step 1: Add the flag**
+
+- Config field: `SkipBlockRefCleanup bool`
+- Flag: `flag.BoolVar(&config.SkipBlockRefCleanup, "skip-block-ref-cleanup", false, "Skip one-shot cleanup of dangling references in note_blocks")`
+- Env: `SKIP_BLOCK_REF_CLEANUP=1`
+
+- [ ] **Step 2: Add `migrateBlockReferencesOnce`**
+
+```go
+// migrateBlockReferencesOnce scans note_blocks for dangling IDs and removes them.
+// One-shot: records completion in plugin_kv (existing table) so it doesn't re-run.
+func migrateBlockReferencesOnce(db *gorm.DB) error {
+    const markerKey = "block_ref_cleanup_v1"
+
+    var completed models.PluginKV
+    db.Where("plugin_name = ? AND key = ?", "_system", markerKey).First(&completed)
+    if completed.Value == "done" {
+        return nil
+    }
+
+    // Load all note_blocks once, scrub each against current target tables.
+    var blocks []struct {
+        ID      uint
+        Type    string
+        Content string
+    }
+    if err := db.Raw(
+        `SELECT id, type, CAST(content AS TEXT) AS content FROM note_blocks
+         WHERE type IN ('gallery','references','calendar','table')`,
+    ).Scan(&blocks).Error; err != nil {
+        return err
+    }
+
+    // Pre-fetch existing IDs so we scrub only truly missing ones.
+    existingResources := map[uint]bool{}
+    existingGroups := map[uint]bool{}
+    existingQueries := map[uint]bool{}
+    db.Raw(`SELECT id FROM resources`).Scan(&[]uint{}) // warmup; overwritten below
+    {
+        var rows []uint
+        db.Raw(`SELECT id FROM resources`).Scan(&rows)
+        for _, id := range rows {
+            existingResources[id] = true
+        }
+    }
+    {
+        var rows []uint
+        db.Raw(`SELECT id FROM groups`).Scan(&rows)
+        for _, id := range rows {
+            existingGroups[id] = true
+        }
+    }
+    {
+        var rows []uint
+        db.Raw(`SELECT id FROM saved_mrql_queries`).Scan(&rows)
+        for _, id := range rows {
+            existingQueries[id] = true
+        }
+    }
+
+    for _, b := range blocks {
+        updated := b.Content
+        anyChanged := false
+
+        switch b.Type {
+        case "gallery":
+            updated, anyChanged = scrubMissingIdsFromArrayField(updated, "resourceIds", existingResources)
+            updated2, changed2 := scrubMissingCalendarResources(updated, existingResources)
+            if changed2 {
+                updated = updated2
+                anyChanged = true
+            }
+        case "references":
+            updated, anyChanged = scrubMissingIdsFromArrayField(updated, "groupIds", existingGroups)
+        case "calendar":
+            updated, anyChanged = scrubMissingCalendarResources(updated, existingResources)
+        case "table":
+            updated, anyChanged = scrubMissingQueryIdField(updated, existingQueries)
+        }
+
+        if anyChanged {
+            if err := db.Exec(
+                `UPDATE note_blocks SET content = ? WHERE id = ?`, updated, b.ID,
+            ).Error; err != nil {
+                return err
+            }
+        }
+    }
+
+    return db.Exec(
+        `INSERT INTO plugin_kvs (plugin_name, key, value) VALUES ('_system', ?, 'done')
+         ON CONFLICT(plugin_name, key) DO UPDATE SET value = excluded.value`,
+        markerKey,
+    ).Error
+}
+
+// Helpers local to migration; structurally identical to the delete-time scrubbers
+// but operate against a live existing-IDs set, not a single to-delete ID.
+func scrubMissingIdsFromArrayField(content, field string, existing map[uint]bool) (string, bool) {
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(content), &raw); err != nil {
+        return content, false
+    }
+    ids, ok := raw[field].([]any)
+    if !ok {
+        return content, false
+    }
+    filtered := make([]any, 0, len(ids))
+    changed := false
+    for _, v := range ids {
+        if existing[toUint(v)] {
+            filtered = append(filtered, v)
+        } else {
+            changed = true
+        }
+    }
+    if !changed {
+        return content, false
+    }
+    raw[field] = filtered
+    out, _ := json.Marshal(raw)
+    return string(out), true
+}
+
+func scrubMissingCalendarResources(content string, existing map[uint]bool) (string, bool) {
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(content), &raw); err != nil {
+        return content, false
+    }
+    cals, ok := raw["calendars"].([]any)
+    if !ok {
+        return content, false
+    }
+    changed := false
+    for i, c := range cals {
+        cmap, ok := c.(map[string]any)
+        if !ok {
+            continue
+        }
+        source, ok := cmap["source"].(map[string]any)
+        if !ok {
+            continue
+        }
+        if rid, ok := source["resourceId"]; ok && !existing[toUint(rid)] {
+            delete(source, "resourceId")
+            cmap["source"] = source
+            cals[i] = cmap
+            changed = true
+        }
+    }
+    if !changed {
+        return content, false
+    }
+    raw["calendars"] = cals
+    out, _ := json.Marshal(raw)
+    return string(out), true
+}
+
+func scrubMissingQueryIdField(content string, existing map[uint]bool) (string, bool) {
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(content), &raw); err != nil {
+        return content, false
+    }
+    if qid, ok := raw["queryId"]; ok && !existing[toUint(qid)] {
+        delete(raw, "queryId")
+        out, _ := json.Marshal(raw)
+        return string(out), true
+    }
+    return content, false
+}
+```
+
+If the `plugin_kvs` table schema differs from what the marker query assumes, grep `models/` for `PluginKV` and adapt the column names.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application_context/context.go
+git commit -m "feat(blocks): BH-020 — one-shot dangling-ref cleanup migration with SKIP_BLOCK_REF_CLEANUP"
+```
+
+## Task 5: BH-024 fix — 500 → 404 on dangling query
+
+**Files:**
+- Modify: `server/api_handlers/block_api_handlers.go`
+
+- [ ] **Step 1: Write the failing test**
+
+**Files:** Create `server/api_tests/table_block_dangling_query_returns_404_test.go`:
+
+```go
+package api_tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableBlock_DanglingQueryReturns404(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Create a saved query, reference it in a table block, then delete the query.
+	form := url.Values{}
+	form.Set("Name", "bh024-q")
+	form.Set("Content", "type = note")
+	queryRR := tc.MakeFormRequest(http.MethodPost, "/v1/mrql/saved", form)
+	require.Equal(t, http.StatusOK, queryRR.Code)
+
+	var query map[string]any
+	json.Unmarshal(queryRR.Body.Bytes(), &query)
+	queryID := uint(query["ID"].(float64))
+
+	note := tc.CreateDummyNote("bh024-tablenote")
+	blockForm := url.Values{}
+	blockForm.Set("NoteId", fmt.Sprintf("%d", note.ID))
+	blockForm.Set("Type", "table")
+	blockForm.Set("Content", fmt.Sprintf(`{"queryId":%d}`, queryID))
+	blockRR := tc.MakeFormRequest(http.MethodPost, "/v1/note/block", blockForm)
+	require.Equal(t, http.StatusOK, blockRR.Code)
+
+	// Parse out blockId from response
+	var block map[string]any
+	json.Unmarshal(blockRR.Body.Bytes(), &block)
+	blockID := uint(block["ID"].(float64))
+
+	// NOTE: BH-020's fix would scrub the queryId on delete. To test BH-024 specifically,
+	// delete via SQL directly to bypass the scrubber, leaving the dangling reference.
+	tc.DB.Exec(`DELETE FROM saved_mrql_queries WHERE id = ?`, queryID)
+
+	// Now GET the table block's query endpoint
+	getRR := tc.MakeRequest(http.MethodGet, fmt.Sprintf("/v1/note/block/table/query?blockId=%d", blockID), nil)
+	assert.Equal(t, http.StatusNotFound, getRR.Code, "dangling query must yield 404 (BH-024)")
+}
+```
+
+Run 3× to verify fail with 500.
+
+- [ ] **Step 2: Fix — wrap the inner query fetch**
+
+In `block_api_handlers.go`, find the table-block query handler. Where the inner query fetch happens:
+
+```go
+query, err := ctx.GetSavedMRQLQuery(content.QueryID)
+if err != nil {
+    http_utils.HandleError(w, err)  // BUG: returned 500 for ErrRecordNotFound
+    return
+}
+```
+
+Replace with:
+
+```go
+query, err := ctx.GetSavedMRQLQuery(content.QueryID)
+if err != nil {
+    statusCode := server.StatusCodeForError(err)
+    http.Error(w, err.Error(), statusCode)
+    return
+}
+```
+
+Or equivalent — use whichever helper other endpoints (`/v1/note`, `/v1/group`) use to translate `gorm.ErrRecordNotFound` → 404 (typically `statusCodeForError` in `server/api_handlers/error_status.go`).
+
+- [ ] **Step 3: Run the test 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestTableBlock_DanglingQueryReturns404 -v -count=3
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/api_handlers/block_api_handlers.go server/api_tests/table_block_dangling_query_returns_404_test.go
+git commit -m "fix(blocks): BH-024 — dangling query reference returns 404, not 500"
+```
+
+## Task 6: UI graceful-degrade (low risk, high user value)
+
+**Files:**
+- Modify: `src/components/blocks/gallery.js` (or whichever file renders gallery)
+- Modify: `src/components/blocks/references.js`
+- Modify: `src/components/blocks/table.js`
+
+- [ ] **Step 1: In each block component's resource/group/query fetch, handle 404 responses by setting a flag on the local item and rendering "Resource unavailable" / "Group unavailable" / "Query unavailable" instead of dropping into a console error**
+
+Pattern (gallery):
+
+```js
+async fetchResource(id) {
+  const resp = await fetch(`/v1/resource?id=${id}`, { headers: { Accept: 'application/json' } });
+  if (resp.status === 404) {
+    return { __unavailable: true, id };
+  }
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+```
+
+Render:
+
+```html
+<template x-if="resource.__unavailable">
+  <span class="resource-unavailable" x-text="'Resource #' + resource.id + ' unavailable'"></span>
+</template>
+```
+
+- [ ] **Step 2: Rebuild JS bundle**
+
+```bash
+npm run build-js
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/blocks public/dist
+git commit -m "feat(blocks): BH-020 — graceful 'unavailable' render for dangling refs"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Full Go suite**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+- [ ] **Step 2: Rebase + full E2E + Postgres.**
+
+- [ ] **Step 3: Open PR, self-merge**
+
+```bash
+gh pr create --title "fix(blocks): BH-020, BH-024 — deletion-cascade + dangling-ref 404" --body "$(cat <<'EOF'
+Closes BH-020, BH-024.
+
+## Changes
+
+- `application_context/block_ref_cleanup.go` — shared scrubber for gallery / references / calendar / table block content.
+- Resource / group / saved-query delete handlers now call the scrubber inside the delete transaction.
+- One-shot boot migration cleans up pre-existing orphans, gated by `SKIP_BLOCK_REF_CLEANUP=1`.
+- `server/api_handlers/block_api_handlers.go` — table-block query handler translates `ErrRecordNotFound` → 404 via `statusCodeForError` (BH-024, 2-line fix).
+- Block UI components render "Resource/Group/Query unavailable" on 404 instead of logging errors.
+
+## Tests
+
+- Unit: ✓ `block_ref_cleanup_test.go`
+- Go API: ✓ 4 integration tests, one per block type, pass 3× pre-fix red / post-fix green.
+- Go API: ✓ BH-024 dangling query → 404 test, 3× pre red / post green.
+- Full `go test ./...`: ✓
+- Full E2E: ✓
+- Postgres: ✓
+
+## Operator note
+
+The one-shot migration runs at startup. On deployments with millions of resources, set `SKIP_BLOCK_REF_CLEANUP=1` to defer.
+
+## Bug-hunt-log update
+
+Post-merge: move BH-020 and BH-024 to Fixed / closed.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c5-jobs-ui-a11y.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c5-jobs-ui-a11y.md
@@ -1,0 +1,467 @@
+# Cluster 5 — Jobs UI + Download Cockpit A11y (BH-025, BH-026, BH-028)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Solo subagent because the three bugs touch overlapping files (`adminExport.js`, `downloadCockpit.js`, `downloadCockpit.tpl`). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the export page survive a reload (BH-025), give completed group-export jobs a visible title + download link in the download cockpit (BH-026), and bring the cockpit panel up to WCAG-A for focus + progress announcements (BH-028).
+
+**Architecture:** `adminExport.init()` subscribes to the jobs SSE stream (same pattern `downloadCockpit.connect()` already uses) and rehydrates the current `this.job` from `localStorage`. `downloadCockpit.tpl` gains a third completion-time template branch for `source == 'group-export'` and a fallback title. Panel gains dialog ARIA + focus trap; progress bars gain `role="progressbar"` + `aria-valuenow`; connection-status dot gains `aria-label`.
+
+**Tech Stack:** Alpine.js, Pongo2 templates, Playwright E2E with axe-core.
+
+**Worktree branch:** `bugfix/c5-jobs-ui-a11y`
+
+---
+
+## File structure
+
+**Modified:**
+- `src/components/adminExport.js` — init() subscribes to SSE, rehydrates `this.job` from localStorage
+- `src/components/downloadCockpit.js` — `getJobTitle()` fallback, progress/connection ARIA
+- `templates/partials/downloadCockpit.tpl` — new template branch for group-export completion, dialog role, progressbar ARIA, status-dot aria-label
+
+**Created:**
+- `e2e/tests/c5-bh025-admin-export-reload.spec.ts`
+- `e2e/tests/c5-bh026-download-cockpit-group-export-link.spec.ts`
+- `e2e/tests/c5-bh028-download-cockpit-a11y.spec.ts`
+
+---
+
+## Task 1: BH-025 — Failing test for admin-export page reload
+
+**Files:**
+- Create: `e2e/tests/c5-bh025-admin-export-reload.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test.describe('BH-025: adminExport survives reload', () => {
+  test('progress panel re-appears after page reload during running export', async ({ page, apiClient }) => {
+    // Seed a group with a couple of small resources so the export takes longer than a blink.
+    const group = await apiClient.createGroup({ Name: `bh025-grp-${Date.now()}` });
+    // (if apiClient has an upload helper, attach a couple of resources to the group)
+
+    await page.goto('/admin/export');
+    await page.locator(`[data-group-id="${group.ID}"], label:has-text("${group.Name}")`).first().click();
+    await page.locator('button:has-text("Start export"), button[type="submit"]').first().click();
+
+    // Progress panel should show immediately
+    await expect(page.locator('[data-testid="export-progress-panel"]')).toBeVisible();
+
+    // Reload mid-export
+    await page.reload();
+
+    // Progress panel must reappear (BH-025 symptom: it currently does not)
+    await expect(page.locator('[data-testid="export-progress-panel"]')).toBeVisible({ timeout: 5000 });
+  });
+});
+```
+
+If `data-testid` doesn't exist on the progress panel yet, use whatever selector currently identifies the progress area in `adminExport.tpl`; add `data-testid` if needed during the fix.
+
+- [ ] **Step 2: Run 3× to verify fail**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-025" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all 3. After reload, the panel is gone.
+
+## Task 2: BH-025 — Fix adminExport rehydration
+
+**Files:**
+- Modify: `src/components/adminExport.js:31-42`
+- Modify: `templates/adminExport.tpl` — ensure the progress panel has `data-testid="export-progress-panel"` if needed.
+
+- [ ] **Step 1: Update adminExport init to subscribe + rehydrate**
+
+```js
+// adminExport.js Alpine component
+init() {
+  // existing: restore selectedGroups from preselectedIds
+  if (this.preselectedIds) {
+    this.selectedGroups = this.preselectedIds.slice();
+  }
+
+  // NEW: rehydrate in-flight export job from localStorage on reload.
+  const storedJobId = localStorage.getItem('adminExport:currentJobId');
+  if (storedJobId) {
+    this.subscribeProgress(storedJobId, /*rehydrating*/true);
+  }
+},
+
+submit() {
+  // existing POST /v1/group/export
+  // ... on success, set this.job = <the created job>
+  this.job = createdJob;
+  localStorage.setItem('adminExport:currentJobId', String(createdJob.jobId));
+  this.subscribeProgress(createdJob.jobId);
+},
+
+subscribeProgress(jobId, rehydrating = false) {
+  const es = new EventSource('/v1/jobs/stream');
+  es.addEventListener('init', (e) => {
+    const jobs = JSON.parse(e.data);
+    const match = jobs.find(j => j.jobId === jobId || j.id === jobId);
+    if (match) {
+      this.job = match;
+    } else if (rehydrating) {
+      // Stale localStorage entry — the job is gone. Clear it silently.
+      localStorage.removeItem('adminExport:currentJobId');
+      es.close();
+    }
+  });
+  es.addEventListener('update', (e) => {
+    const job = JSON.parse(e.data);
+    if (job.jobId === jobId || job.id === jobId) {
+      this.job = job;
+    }
+  });
+  es.addEventListener('complete', (e) => {
+    const job = JSON.parse(e.data);
+    if (job.jobId === jobId || job.id === jobId) {
+      this.job = job;
+      localStorage.removeItem('adminExport:currentJobId');
+      es.close();
+    }
+  });
+}
+```
+
+Adapt field names to the actual SSE event format (`jobId` vs `id`, etc.) — grep `downloadCockpit.js` for the canonical format.
+
+- [ ] **Step 2: Rebuild JS**
+
+```bash
+npm run build-js
+```
+
+- [ ] **Step 3: Run Task 1 test 3× to verify pass**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-025" --repeat-each=3 --workers=1
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/adminExport.js templates/adminExport.tpl public/dist e2e/tests/c5-bh025-*.spec.ts
+git commit -m "fix(export): BH-025 — adminExport rehydrates job on reload via SSE"
+```
+
+## Task 3: BH-026 — Failing test for completed group-export download link
+
+**Files:**
+- Create: `e2e/tests/c5-bh026-download-cockpit-group-export-link.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-026: completed group export has title + download link in cockpit', async ({ page, apiClient }) => {
+  const group = await apiClient.createGroup({ Name: `bh026-grp-${Date.now()}` });
+  // Kick off an export via the API so we can await its completion
+  const exportResp = await apiClient.post('/v1/group/export', { GroupIds: [group.ID] });
+  const { jobId } = exportResp;
+
+  await page.goto('/');
+  // Poll jobs endpoint until complete
+  await expect.poll(async () => {
+    const jobs = await apiClient.get('/v1/jobs');
+    const job = jobs.find((j: any) => j.jobId === jobId || j.id === jobId);
+    return job?.status;
+  }, { timeout: 30000 }).toBe('completed');
+
+  // Open the download cockpit panel
+  await page.locator('[data-testid="cockpit-trigger"], button:has-text("Jobs")').first().click();
+
+  const jobRow = page.locator('[data-testid="cockpit-job"]', { hasText: /Group export|bh026/i });
+  await expect(jobRow).toBeVisible();
+
+  // Job row must have a visible non-empty title
+  const title = await jobRow.locator('[data-testid="cockpit-job-title"]').textContent();
+  expect(title?.trim()).not.toBe('');
+
+  // Job row must expose a download link
+  const download = jobRow.locator('a[href*="/exports/"][href*="/download"]');
+  await expect(download).toBeVisible();
+});
+```
+
+Add `data-testid` attributes in the template as needed.
+
+- [ ] **Step 2: Run 3× to verify fail**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-026" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all 3 (title empty, no download link).
+
+## Task 4: BH-026 — Fix title fallback + add download branch
+
+**Files:**
+- Modify: `src/components/downloadCockpit.js:338-360` (the `getJobTitle` / `getFilename` area)
+- Modify: `templates/partials/downloadCockpit.tpl:156-169` (the completion-time branch)
+
+- [ ] **Step 1: Extend getJobTitle**
+
+```js
+getJobTitle(job) {
+  if (job.url) return this.getFilename(job.url);
+  if (job.source === 'group-export') {
+    return job.name || job.groupName || 'Group export';
+  }
+  if (job._isAction) return job.name || 'Action';
+  return job.name || 'Download';
+},
+```
+
+- [ ] **Step 2: Add the template branch for group-export completion**
+
+In `downloadCockpit.tpl` where the completion row is rendered, add a third branch:
+
+```html
+<template x-if="job.status === 'completed' && job.source === 'group-export' && job.resultPath">
+  <a :href="'/v1/exports/' + (job.jobId || job.id) + '/download'"
+     class="download-link"
+     data-testid="cockpit-job-download">
+    Download
+  </a>
+</template>
+```
+
+Make sure the row also renders the title with `data-testid="cockpit-job-title"`:
+
+```html
+<span class="job-title" data-testid="cockpit-job-title" x-text="getJobTitle(job)"></span>
+```
+
+- [ ] **Step 3: Rebuild and run Task 3 test 3×**
+
+```bash
+npm run build-js
+cd e2e
+npm run test:with-server -- --grep "BH-026" --repeat-each=3 --workers=1
+```
+
+Expected: PASS all 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/downloadCockpit.js templates/partials/downloadCockpit.tpl public/dist e2e/tests/c5-bh026-*.spec.ts
+git commit -m "fix(jobs): BH-026 — completed group-export has title + download link in cockpit"
+```
+
+## Task 5: BH-028 — Failing a11y test for cockpit panel
+
+**Files:**
+- Create: `e2e/tests/c5-bh028-download-cockpit-a11y.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/a11y.fixture';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('BH-028: download cockpit panel a11y', () => {
+  test('panel has dialog ARIA and initial focus lands inside', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('[data-testid="cockpit-trigger"]').click();
+
+    const panel = page.locator('[data-testid="cockpit-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel).toHaveAttribute('role', 'dialog');
+    await expect(panel).toHaveAttribute('aria-modal', 'true');
+
+    const activeTag = await page.evaluate(() => document.activeElement?.closest('[data-testid="cockpit-panel"]'));
+    expect(activeTag, 'focus must move into the panel on open').not.toBeNull();
+  });
+
+  test('progress bar has ARIA', async ({ page, apiClient }) => {
+    // Start any download or export that produces a progress bar quickly.
+    // (Implementation-specific: kick off a group export, open panel.)
+    await page.goto('/');
+    await page.locator('[data-testid="cockpit-trigger"]').click();
+    const anyProgress = page.locator('[data-testid="cockpit-progressbar"]').first();
+    if (await anyProgress.count()) {
+      await expect(anyProgress).toHaveAttribute('role', 'progressbar');
+      await expect(anyProgress).toHaveAttribute('aria-valuemin', '0');
+      await expect(anyProgress).toHaveAttribute('aria-valuemax', '100');
+    } else {
+      test.skip(true, 'no active job — progressbar test requires an in-flight download');
+    }
+  });
+
+  test('connection status has accessible name', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('[data-testid="cockpit-trigger"]').click();
+    const dot = page.locator('[data-testid="cockpit-connection-status"]');
+    await expect(dot).toBeVisible();
+    const ariaLabel = await dot.getAttribute('aria-label');
+    expect(ariaLabel).toBeTruthy();
+    expect(ariaLabel).toMatch(/connection/i);
+  });
+
+  test('axe finds zero Serious+ violations on open panel', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('[data-testid="cockpit-trigger"]').click();
+    await page.waitForSelector('[data-testid="cockpit-panel"]');
+
+    const scan = await new AxeBuilder({ page })
+      .include('[data-testid="cockpit-panel"]')
+      .disableRules(['region']) // region rule is noisy on overlays
+      .analyze();
+
+    const seriousPlus = scan.violations.filter(v => v.impact === 'serious' || v.impact === 'critical');
+    expect(seriousPlus).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run 3× to verify fail (or skip if selectors need adding)**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-028" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL (dialog role missing, focus not moving, progressbar role missing, aria-label missing).
+
+## Task 6: BH-028 — Fix panel ARIA + focus + progressbar + connection-dot
+
+**Files:**
+- Modify: `templates/partials/downloadCockpit.tpl:28` (panel), `:110-115` (progress bars), `:40-47` (status dot)
+- Modify: `src/components/downloadCockpit.js` — focus trap on open
+
+- [ ] **Step 1: Panel dialog ARIA + focus trap**
+
+Template:
+
+```html
+<div x-show="isOpen"
+     x-ref="panel"
+     data-testid="cockpit-panel"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="jobs-panel-heading"
+     tabindex="-1">
+  <h2 id="jobs-panel-heading">Jobs</h2>
+  <!-- ... -->
+</div>
+```
+
+Component:
+
+```js
+init() {
+  this.$watch('isOpen', (open) => {
+    if (open) {
+      // defer until element is visible
+      this.$nextTick(() => {
+        const firstFocusable = this.$refs.panel.querySelector('button, [href], [tabindex]:not([tabindex="-1"])');
+        (firstFocusable || this.$refs.panel).focus();
+      });
+    } else if (this.lastTrigger) {
+      this.lastTrigger.focus();
+    }
+  });
+},
+
+open(event) {
+  this.lastTrigger = event?.currentTarget;
+  this.isOpen = true;
+}
+```
+
+- [ ] **Step 2: Progress bar ARIA**
+
+```html
+<div class="progress-bar-container"
+     role="progressbar"
+     data-testid="cockpit-progressbar"
+     :aria-valuenow="Math.min(100, Math.round(job?.progressPercent || 0))"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     :aria-label="'Download progress: ' + formatProgress(job)">
+  <div class="progress-bar-fill" :style="'width:' + getProgressPercent(job) + '%'"></div>
+</div>
+```
+
+- [ ] **Step 3: Connection status dot**
+
+```html
+<span x-ref="connectionStatus"
+      data-testid="cockpit-connection-status"
+      role="img"
+      :aria-label="'Connection status: ' + connectionStatus"
+      :class="connectionClass"></span>
+```
+
+- [ ] **Step 4: Rebuild and run Task 5 tests 3×**
+
+```bash
+npm run build-js
+cd e2e
+npm run test:with-server -- --grep "BH-028" --repeat-each=3 --workers=1
+```
+
+Expected: PASS all 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/downloadCockpit.js templates/partials/downloadCockpit.tpl public/dist e2e/tests/c5-bh028-*.spec.ts
+git commit -m "fix(a11y): BH-028 — download cockpit dialog role, focus trap, progressbar, status aria-label"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Full Go + E2E (targeted)**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+cd e2e && npm run test:with-server -- --grep "BH-02[568]"
+```
+
+- [ ] **Step 2: Rebase + full suite per master plan.**
+
+- [ ] **Step 3: Open PR, self-merge**
+
+```bash
+gh pr create --title "fix(jobs): BH-025, BH-026, BH-028 — export reload + cockpit a11y" --body "$(cat <<'EOF'
+Closes BH-025, BH-026, BH-028.
+
+## Changes
+
+- `src/components/adminExport.js` — init() subscribes to `/v1/jobs/stream` and rehydrates the in-flight job from localStorage on reload.
+- `src/components/downloadCockpit.js` — `getJobTitle()` falls back to `job.source === 'group-export'` → "Group export"; focus trap on panel open/close.
+- `templates/partials/downloadCockpit.tpl` — new completion branch wiring `source === 'group-export'` + `resultPath` to `/v1/exports/{jobId}/download`; panel gains `role="dialog"` + `aria-modal="true"`; progress bars gain `role="progressbar"` + `aria-valuenow`; status dot gains `aria-label`.
+
+## Tests
+
+- E2E: 3 new specs for BH-025, BH-026, BH-028 — pass 3× pre-fix red / post-fix green.
+- Go unit + API: ✓
+- Full E2E: ✓
+- Postgres: ✓
+
+## Bug-hunt-log update
+
+Post-merge: BH-025, BH-026, BH-028 → Fixed / closed.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c6-block-editor-a11y.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c6-block-editor-a11y.md
@@ -1,0 +1,333 @@
+# Cluster 6 — Block Editor A11y (BH-027)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Solo subagent. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close 4 WCAG-A violations in the block-editor authoring surface (2 axe-critical, 2 serious).
+
+**Architecture:** Additive ARIA attributes on the block-editor template and a lightweight Alpine extension for the Add-Block picker's roving tabindex behavior.
+
+**Tech Stack:** Pongo2 templates, Alpine.js, Playwright + axe-core.
+
+**Worktree branch:** `bugfix/c6-block-editor-a11y`
+
+---
+
+## File structure
+
+**Modified:**
+- `templates/partials/blockEditor.tpl` — gallery img alt, heading-level select aria-label, reorder/delete icon aria-label, Add-Block picker disclosure ARIA + listbox + roving tabindex.
+- `src/components/blockEditor.js` — Arrow-key navigation for Add-Block picker; live-region announcement on block reorder.
+
+**Created:**
+- `e2e/tests/c6-bh027-block-editor-a11y.spec.ts`
+
+---
+
+## Task 1: Failing axe-core spec for block editor
+
+**Files:**
+- Create: `e2e/tests/c6-bh027-block-editor-a11y.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test, expect } from '../fixtures/a11y.fixture';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('BH-027: block editor a11y', () => {
+  test('axe finds zero Critical violations on the block editor', async ({ page, apiClient }) => {
+    const note = await apiClient.createNote({ Name: `bh027-${Date.now()}` });
+    // Add a gallery block with at least one image so the image-alt rule has targets
+    // (implementation-specific — may need to use existing test helpers).
+
+    await page.goto(`/note/edit?id=${note.ID}`);
+    await page.waitForSelector('[data-testid="block-editor"], .block-editor');
+
+    const scan = await new AxeBuilder({ page })
+      .include('.block-editor')
+      .analyze();
+
+    const critical = scan.violations.filter(v => v.impact === 'critical');
+    expect(critical, JSON.stringify(critical, null, 2)).toEqual([]);
+  });
+
+  test('gallery images have non-empty alt', async ({ page, apiClient }) => {
+    const note = await apiClient.createNote({ Name: `bh027-gallery-${Date.now()}` });
+    // Add gallery block with test resource, via existing helpers or direct DB seed.
+    await page.goto(`/note/edit?id=${note.ID}`);
+
+    const galleryImgs = page.locator('.block-gallery img, [data-block-type="gallery"] img');
+    const count = await galleryImgs.count();
+    if (count === 0) test.skip(true, 'no gallery images seeded — skip image-alt assertion');
+
+    for (let i = 0; i < count; i++) {
+      const alt = await galleryImgs.nth(i).getAttribute('alt');
+      expect(alt).not.toBeNull();
+      expect(alt!.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('heading-level select has accessible name', async ({ page, apiClient }) => {
+    const note = await apiClient.createNote({ Name: `bh027-h-${Date.now()}` });
+    await page.goto(`/note/edit?id=${note.ID}`);
+    // Insert a heading block via the UI
+    await page.locator('button[aria-label="Add block"], [data-testid="add-block-trigger"]').click();
+    await page.locator('[role="listbox"] [data-block-type="heading"], text=Heading').first().click();
+
+    const levelSelect = page.locator('[data-block-type="heading"] select').last();
+    const ariaLabel = await levelSelect.getAttribute('aria-label');
+    expect(ariaLabel).toMatch(/heading level/i);
+  });
+
+  test('move + delete buttons have aria-labels', async ({ page, apiClient }) => {
+    const note = await apiClient.createNote({ Name: `bh027-ctrl-${Date.now()}` });
+    await page.goto(`/note/edit?id=${note.ID}`);
+    // Add two blocks so move-up/down appear
+    for (let i = 0; i < 2; i++) {
+      await page.locator('button[aria-label="Add block"], [data-testid="add-block-trigger"]').click();
+      await page.locator('[role="listbox"] text=Text, [data-block-type="text"]').first().click();
+    }
+
+    const buttons = page.locator('[data-block-control]');
+    const count = await buttons.count();
+    for (let i = 0; i < count; i++) {
+      const aria = await buttons.nth(i).getAttribute('aria-label');
+      expect(aria, `block control #${i} missing aria-label`).toBeTruthy();
+    }
+  });
+
+  test('add-block picker exposes disclosure + listbox semantics', async ({ page, apiClient }) => {
+    const note = await apiClient.createNote({ Name: `bh027-picker-${Date.now()}` });
+    await page.goto(`/note/edit?id=${note.ID}`);
+
+    const trigger = page.locator('[data-testid="add-block-trigger"]');
+    await expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const list = page.locator('[role="listbox"][aria-label="Block types"]');
+    await expect(list).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run 3× to verify fail**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-027" --repeat-each=3 --workers=1
+```
+
+Expected: FAIL all 3 on at least the "zero critical" assertion.
+
+## Task 2: Fix gallery `<img>` alt
+
+**Files:**
+- Modify: `templates/partials/blockEditor.tpl:181-183, 197`
+
+- [ ] **Step 1: Add dynamic alt**
+
+```html
+<img :src="resourceThumbUrl(resId)"
+     :alt="getResourceName(resId) || 'Resource ' + resId"
+     loading="lazy">
+```
+
+If `getResourceName` doesn't exist on the component, add it. The component already fetches resource metadata for gallery rendering — reuse that cache.
+
+## Task 3: Fix heading-level select
+
+**Files:**
+- Modify: `templates/partials/blockEditor.tpl:112`
+
+- [ ] **Step 1: Add aria-label**
+
+```html
+<select aria-label="Heading level" x-model.number="level" @change="save()">
+  <option value="1">H1</option>
+  <option value="2">H2</option>
+  <option value="3">H3</option>
+</select>
+```
+
+## Task 4: Fix move + delete buttons
+
+**Files:**
+- Modify: `templates/partials/blockEditor.tpl:37-65`
+
+- [ ] **Step 1: Add aria-labels and a data-attribute for the test**
+
+```html
+<button type="button"
+        data-block-control="move-up"
+        :aria-label="'Move block ' + (index + 1) + ' up'"
+        @click="moveUp(index)">
+  <!-- existing icon -->
+</button>
+<button type="button"
+        data-block-control="move-down"
+        :aria-label="'Move block ' + (index + 1) + ' down'"
+        @click="moveDown(index)">
+  <!-- existing icon -->
+</button>
+<button type="button"
+        data-block-control="delete"
+        :aria-label="'Delete block ' + (index + 1)"
+        @click="remove(index)">
+  <!-- existing icon -->
+</button>
+```
+
+- [ ] **Step 2: Add live-region announcement on reorder**
+
+In `blockEditor.js`, add a `$refs.live` element in the template (`<div x-ref="live" class="sr-only" aria-live="polite"></div>`) and:
+
+```js
+moveUp(index) {
+  // existing reorder
+  this.$refs.live.textContent = `Block ${index + 1} moved up`;
+},
+moveDown(index) {
+  // existing reorder
+  this.$refs.live.textContent = `Block ${index + 1} moved down`;
+}
+```
+
+## Task 5: Fix Add-Block picker disclosure + listbox + roving tabindex
+
+**Files:**
+- Modify: `templates/partials/blockEditor.tpl:862-888`
+- Modify: `src/components/blockEditor.js` — keyboard handler
+
+- [ ] **Step 1: Add disclosure ARIA to trigger**
+
+```html
+<button type="button"
+        data-testid="add-block-trigger"
+        :aria-expanded="addBlockPickerOpen.toString()"
+        aria-haspopup="listbox"
+        aria-controls="add-block-listbox"
+        @click="addBlockPickerOpen = !addBlockPickerOpen"
+        @keydown.escape="addBlockPickerOpen = false">
+  Add block
+</button>
+```
+
+- [ ] **Step 2: Add listbox semantics**
+
+```html
+<ul id="add-block-listbox"
+    role="listbox"
+    aria-label="Block types"
+    x-show="addBlockPickerOpen"
+    @keydown.escape="addBlockPickerOpen = false">
+  <template x-for="(btype, idx) in blockTypes" :key="btype.name">
+    <li role="option"
+        :tabindex="idx === activePickerIndex ? 0 : -1"
+        :aria-selected="idx === activePickerIndex"
+        :data-block-type="btype.name"
+        @click="insertBlock(btype.name)"
+        @keydown.enter="insertBlock(btype.name)"
+        @keydown.arrow-down.prevent="activePickerIndex = Math.min(activePickerIndex + 1, blockTypes.length - 1)"
+        @keydown.arrow-up.prevent="activePickerIndex = Math.max(activePickerIndex - 1, 0)"
+        @keydown.home.prevent="activePickerIndex = 0"
+        @keydown.end.prevent="activePickerIndex = blockTypes.length - 1">
+      <span x-text="btype.label"></span>
+    </li>
+  </template>
+</ul>
+```
+
+- [ ] **Step 3: Initialize `activePickerIndex` in the component**
+
+```js
+addBlockPickerOpen: false,
+activePickerIndex: 0,
+
+// when the picker opens, reset index and focus the active item
+$watch: {
+  addBlockPickerOpen(open) {
+    if (open) {
+      this.activePickerIndex = 0;
+      this.$nextTick(() => {
+        this.$el.querySelector('[role="option"]:not([tabindex="-1"])')?.focus();
+      });
+    }
+  }
+}
+```
+
+(Adapt to however $watch is wired in the existing Alpine code — may be `init()` + explicit subscribe.)
+
+## Task 6: Rebuild and run all BH-027 tests 3× to verify pass
+
+- [ ] **Step 1:**
+
+```bash
+npm run build-js
+cd e2e
+npm run test:with-server -- --grep "BH-027" --repeat-each=3 --workers=1
+```
+
+Expected: PASS all 3 runs across all sub-tests.
+
+- [ ] **Step 2: Run full a11y suite to ensure no regression elsewhere**
+
+```bash
+cd e2e
+npm run test:with-server:a11y
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/partials/blockEditor.tpl src/components/blockEditor.js public/dist e2e/tests/c6-bh027-*.spec.ts
+git commit -m "fix(a11y): BH-027 — block editor gallery alt, heading label, control aria-labels, picker listbox"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Full Go + full E2E a11y**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+cd e2e && npm run test:with-server:a11y
+```
+
+- [ ] **Step 2: Rebase + full suite per master plan.**
+
+- [ ] **Step 3: Open PR, self-merge**
+
+```bash
+gh pr create --title "fix(a11y): BH-027 — block editor WCAG-A violations" --body "$(cat <<'EOF'
+Closes BH-027.
+
+## Changes
+
+- Gallery `<img>`: dynamic `:alt` using resource name.
+- Heading-level `<select>`: `aria-label="Heading level"`.
+- Move-up / move-down / delete icon buttons: dynamic `:aria-label`; live-region announcement on reorder.
+- Add-Block picker: `aria-expanded`, `aria-haspopup="listbox"`, `aria-controls` on trigger; `role="listbox"` + `aria-label="Block types"` + roving tabindex + Arrow/Home/End navigation on options.
+
+## Tests
+
+- E2E (axe + targeted assertions): 5 sub-tests, pass 3× pre red / post green.
+- Full a11y suite: ✓
+- Full E2E: ✓
+
+## Bug-hunt-log update
+
+Post-merge: BH-027 → Fixed / closed.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c7-alt-fs.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c7-alt-fs.md
@@ -1,0 +1,444 @@
+# Cluster 7 — Alt-FS Round-Trip Completion (BH-023)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Solo subagent, three serial layers. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the `FILE_ALT_*` alternative-filesystem feature actually usable end-to-end: UI selector on create-resource, multipart API accepts `PathName`, export/import preserves `storage_location`.
+
+**Architecture:** Three thin additions across layers.
+
+1. **Manifest:** `ResourcePayload` (in `archive/manifest.go`) gains optional `storage_location`. Forward-compatible per the stable-contract rule — no `schema_version` bump.
+2. **API:** `ResourceCreator` (in `models/query_models/resource_query.go`) gains `PathName` field; `AddResource` threads it to the resource's `StorageLocation`.
+3. **UI:** `templates/createResource.tpl` renders a `<select>` populated from `config.altFileSystems` when non-empty.
+
+**Tech Stack:** Go, Pongo2, Playwright E2E.
+
+**Worktree branch:** `bugfix/c7-alt-fs`
+
+---
+
+## File structure
+
+**Modified:**
+- `archive/manifest.go` — add `StorageLocation string ``json:"storage_location,omitempty"`` ` to `ResourcePayload`
+- `application_context/export_context.go` — exporter sets `StorageLocation` when resource has one
+- `application_context/apply_import.go` (or `import_plan.go`) — importer applies `StorageLocation` on resource creation
+- `models/query_models/resource_query.go` — add `PathName` field to `ResourceCreator`
+- `application_context/resource_context.go` — `AddResource` threads `PathName` → `resource.StorageLocation`
+- `templates/createResource.tpl` — new `<select name="PathName">` when alt-fs configured
+- `server/template_handlers/template_context_providers/resource_template_context.go` — expose `altFileSystems` to create template if not already
+
+**Created:**
+- `server/api_tests/resource_create_pathname_test.go` — BH-023 part 2 (multipart path)
+- `application_context/export_import_altfs_test.go` — BH-023 part 1 (round-trip)
+- `e2e/tests/c7-bh023-alt-fs-select-visible.spec.ts` — BH-023 part 3 (UI)
+
+---
+
+## Pre-work: confirm `ResourcePayload` structure and export test harness
+
+- [ ] **Step 1: Inspect `archive/manifest.go`**
+
+```bash
+grep -n "ResourcePayload\|schema_version\|storage_location" archive/manifest.go | head -30
+```
+
+Confirm the JSON tag style and where to add the field. The CLAUDE.md rule is: adding an optional field is forward-compatible (unknown keys ignored by older readers), so no schema_version bump.
+
+- [ ] **Step 2: Find the export/import round-trip pattern in existing tests**
+
+```bash
+grep -rn "ExportGroup\|ApplyImport\|manifest" application_context/*_test.go | head -20
+```
+
+Reuse whatever helper already exists for round-trip tests. If none, construct a minimal one inside the new test file.
+
+---
+
+## Task 1: Failing multipart PathName test
+
+**Files:**
+- Create: `server/api_tests/resource_create_pathname_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceCreate_PathNamePersistsStorageLocation(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Configure an alt-fs in the test environment. If SetupTestEnv doesn't
+	// support this directly, add a helper or set the config before the
+	// request (AppCtx.Config.AltFileSystems is the likely hook).
+	tc.AppCtx.Config.AltFileSystems = map[string]string{"archival": "/tmp/archival-test"}
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+
+	part, err := w.CreateFormFile("File", "bh023.txt")
+	require.NoError(t, err)
+	_, err = io.Copy(part, bytes.NewReader([]byte("hello")))
+	require.NoError(t, err)
+
+	require.NoError(t, w.WriteField("Name", "bh023-altfs"))
+	require.NoError(t, w.WriteField("PathName", "archival"))
+	require.NoError(t, w.Close())
+
+	req, _ := http.NewRequest(http.MethodPost, "/v1/resource", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	tc.Router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "resource create failed: %s", rr.Body.String())
+
+	var resource map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resource))
+
+	assert.Equal(t, "archival", resource["StorageLocation"],
+		"StorageLocation must be preserved from multipart PathName (BH-023)")
+}
+```
+
+- [ ] **Step 2: Run 3× — expect fail (PathName silently dropped)**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestResourceCreate_PathNamePersistsStorageLocation -v -count=3
+```
+
+Expected: FAIL — `StorageLocation` is `""` or `nil`.
+
+## Task 2: Add `PathName` to `ResourceCreator` and thread to `AddResource`
+
+**Files:**
+- Modify: `models/query_models/resource_query.go`
+
+- [ ] **Step 1: Add the field**
+
+Find the `ResourceCreator` struct. Add:
+
+```go
+type ResourceCreator struct {
+    ResourceQueryBase
+    PathName string `json:"pathName" schema:"PathName"` // BH-023: alt-fs key
+}
+```
+
+- [ ] **Step 2: In `AddResource`**
+
+Find the `AddResource` function in `application_context/resource_context.go` (or `resource_media_context.go`). After creating the resource object, before `DB.Create`:
+
+```go
+if query.PathName != "" {
+    if _, ok := ctx.Config.AltFileSystems[query.PathName]; !ok {
+        return nil, fmt.Errorf("unknown filesystem: %s", query.PathName)
+    }
+    resource.StorageLocation = query.PathName
+}
+```
+
+If `AltFileSystems` is a `map[string]string`, this is a direct lookup. If it's a `map[string]Filesystem` with richer metadata, use that lookup instead.
+
+- [ ] **Step 3: Run test 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestResourceCreate_PathNamePersistsStorageLocation -v -count=3
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add models/query_models/resource_query.go application_context/resource_context.go server/api_tests/resource_create_pathname_test.go
+git commit -m "fix(altfs): BH-023 — multipart PathName now persists to StorageLocation"
+```
+
+---
+
+## Task 3: Failing export/import round-trip test
+
+**Files:**
+- Create: `server/api_tests/export_import_altfs_test.go`
+
+Place this test in `server/api_tests/` so it reuses `SetupTestEnv` and the existing `TestContext`. This avoids inventing a new test-context harness in a different package.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mahresources/models"
+)
+
+func TestExportImport_PreservesStorageLocation(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Configure alt-fs on the live context.
+	tc.AppCtx.Config.AltFileSystems = map[string]string{"archival": t.TempDir()}
+
+	// Seed a group + resource that lives in the alt-fs
+	group := &models.Group{Name: "bh023-group"}
+	require.NoError(t, tc.DB.Create(group).Error)
+
+	resource := &models.Resource{
+		Name:            "bh023-res",
+		ContentType:     "text/plain",
+		Size:            5,
+		StorageLocation: "archival",
+	}
+	require.NoError(t, tc.DB.Create(resource).Error)
+	require.NoError(t, tc.DB.Model(group).Association("Resources").Append(resource))
+
+	// Export via the HTTP route to exercise the same code path as a real user.
+	exportReqBody, _ := json.Marshal(map[string]any{"GroupIds": []uint{group.ID}})
+	req, _ := http.NewRequest(http.MethodPost, "/v1/group/export", bytes.NewReader(exportReqBody))
+	req.Header.Set("Content-Type", "application/json")
+	exportRR := httptest.NewRecorder()
+	tc.Router.ServeHTTP(exportRR, req)
+	require.Equal(t, http.StatusOK, exportRR.Code, "export failed: %s", exportRR.Body.String())
+
+	// The export route returns a jobId. Poll jobs (or call the app-context export
+	// helper directly) to get the bytes. For a test, the simplest path is to call
+	// the application_context's synchronous export helper.
+	buf := &bytes.Buffer{}
+	require.NoError(t, tc.AppCtx.ExportGroupsToWriter([]uint{group.ID}, buf))
+
+	// Delete locally so import re-creates
+	require.NoError(t, tc.DB.Unscoped().Delete(&models.Resource{}, resource.ID).Error)
+	require.NoError(t, tc.DB.Unscoped().Delete(&models.Group{}, group.ID).Error)
+
+	// Import via the app-context's import entry point.
+	importResult, err := tc.AppCtx.ApplyImportFromReader(io.NopCloser(bytes.NewReader(buf.Bytes())))
+	require.NoError(t, err)
+	require.NotEmpty(t, importResult.CreatedResources, "no resources created on import")
+
+	var reimported models.Resource
+	require.NoError(t, tc.DB.First(&reimported, importResult.CreatedResources[0]).Error)
+
+	assert.Equal(t, "archival", reimported.StorageLocation,
+		"BH-023: export/import must preserve StorageLocation")
+}
+```
+
+The function names `ExportGroupsToWriter` and `ApplyImportFromReader` are placeholders for the actual synchronous helpers in `application_context/export_context.go` and `application_context/apply_import.go`. Before running the test, grep `application_context/` for the public export/import entry points and substitute the correct names. This is a one-time lookup, not a scoping risk.
+
+- [ ] **Step 2: Run 3× — expect fail with StorageLocation empty after import**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestExportImport_PreservesStorageLocation -v -count=3
+```
+
+Expected: FAIL.
+
+## Task 4: Add `StorageLocation` to `ResourcePayload`, update exporter and importer
+
+**Files:**
+- Modify: `archive/manifest.go` — add field
+- Modify: `application_context/export_context.go` — populate on export
+- Modify: `application_context/apply_import.go` — restore on import
+
+- [ ] **Step 1: Manifest field**
+
+```go
+type ResourcePayload struct {
+    // existing fields...
+    StorageLocation string `json:"storage_location,omitempty"` // BH-023
+}
+```
+
+- [ ] **Step 2: Exporter writes it**
+
+In `export_context.go`, wherever `ResourcePayload` is constructed from a `models.Resource`:
+
+```go
+payload := ResourcePayload{
+    // ... existing ...
+    StorageLocation: resource.StorageLocation,
+}
+```
+
+- [ ] **Step 3: Importer applies it (when present; absent → default fs)**
+
+In `apply_import.go`, wherever a `models.Resource` is built from a `ResourcePayload`:
+
+```go
+resource := &models.Resource{
+    // ... existing ...
+    StorageLocation: payload.StorageLocation, // empty string = default fs
+}
+```
+
+- [ ] **Step 4: Run test 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./application_context/ -run TestExportImport_PreservesStorageLocation -v -count=3
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add archive/manifest.go application_context/export_context.go application_context/apply_import.go application_context/export_import_altfs_test.go
+git commit -m "fix(altfs): BH-023 — export/import preserves storage_location"
+```
+
+---
+
+## Task 5: UI — `<select>` on create-resource
+
+**Files:**
+- Modify: `templates/createResource.tpl`
+- Modify: template context provider (if `altFileSystems` isn't already exposed)
+
+- [ ] **Step 1: Confirm `altFileSystems` availability in template context**
+
+```bash
+grep -rn "altFileSystems\|AltFileSystems" templates/ server/template_handlers/ | head
+```
+
+If the resource-create context provider doesn't expose it, add:
+
+```go
+// server/template_handlers/template_context_providers/resource_template_context.go
+ctx["altFileSystems"] = appContext.Config.AltFileSystems
+```
+
+- [ ] **Step 2: Render the select in the template**
+
+```html
+{% if altFileSystems %}
+<label class="form-row">
+  <span>Storage</span>
+  <select name="PathName" data-testid="resource-storage-select">
+    <option value="">Default</option>
+    {% for key, path in altFileSystems %}
+      <option value="{{ key }}">{{ key }} — {{ path }}</option>
+    {% endfor %}
+  </select>
+</label>
+{% endif %}
+```
+
+(Adjust Pongo2 syntax to match how the codebase iterates `map[string]string` — may need `{% for entry in altFileSystems %}` with `entry.key` / `entry.value`.)
+
+## Task 6: Failing E2E test that the select is visible
+
+**Files:**
+- Create: `e2e/tests/c7-bh023-alt-fs-select-visible.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { test, expect } from '../fixtures/base.fixture';
+
+test('BH-023: resource-create shows Storage select when alt-fs configured', async ({ page }) => {
+  // The ephemeral test server must be started with an alt-fs config for this test
+  // to be meaningful. If the test-server-manager doesn't support it, skip with a
+  // noisy note — the multipart API test already covers the backend path.
+  await page.goto('/resource/new');
+  const select = page.locator('select[name="PathName"], [data-testid="resource-storage-select"]');
+
+  // If no alt-fs is configured in the test env, the select is intentionally absent.
+  const count = await select.count();
+  if (count === 0) {
+    test.skip(true, 'alt-fs not configured in ephemeral server — selector absent is expected');
+  } else {
+    await expect(select).toBeVisible();
+    // Must have at least the default option + one alt-fs key
+    const options = select.locator('option');
+    await expect(options).toHaveCount(await options.count()); // sanity non-zero
+    expect(await options.count()).toBeGreaterThanOrEqual(2);
+  }
+});
+```
+
+- [ ] **Step 2: Run 3× — test either passes (alt-fs configured and select visible) or skips cleanly**
+
+```bash
+cd e2e
+npm run test:with-server -- --grep "BH-023" --repeat-each=3 --workers=1
+```
+
+Expected: 3× PASS or 3× skip, no failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/createResource.tpl server/template_handlers/template_context_providers/resource_template_context.go e2e/tests/c7-bh023-*.spec.ts
+git commit -m "feat(altfs): BH-023 — Storage select on create-resource + template context"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Full Go**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+- [ ] **Step 2: Rebase + full E2E + Postgres**
+
+- [ ] **Step 3: Open PR, self-merge**
+
+```bash
+gh pr create --title "feat(altfs): BH-023 — alt-fs round-trip (UI + multipart + manifest)" --body "$(cat <<'EOF'
+Closes BH-023.
+
+## Changes
+
+- **Manifest (forward-compat, no schema_version bump):** `archive/manifest.go` adds `ResourcePayload.StorageLocation` as optional JSON field. Unknown keys are silently ignored per CLAUDE.md contract, so older readers remain compatible.
+- **Exporter:** populates `storage_location` from `resource.StorageLocation` when non-empty.
+- **Importer:** restores `StorageLocation` when present, defaults to empty (= default filesystem) when absent.
+- **Multipart API:** `ResourceCreator` gains `PathName` field; `AddResource` validates it against `config.AltFileSystems` and sets `resource.StorageLocation`.
+- **UI:** `createResource.tpl` renders a Storage `<select>` populated from `altFileSystems`, visible only when alt-fs is configured.
+
+## Tests
+
+- Go API: ✓ multipart `PathName` test, 3× pre red / post green.
+- Go integration: ✓ export/import round-trip preserves `StorageLocation`, 3× pre red / post green.
+- E2E: ✓ storage select visible when configured, skips cleanly when not.
+- Full `go test ./...`: ✓
+- Full E2E: ✓
+- Postgres: ✓
+
+## Contract note
+
+Manifest change is additive and optional. Per CLAUDE.md's "unknown top-level keys silently ignored" rule, this is forward-compatible with `schema_version: 1`. No version bump.
+
+## Bug-hunt-log update
+
+Post-merge: BH-023 → Fixed / closed.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-c8-share-allowlist.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-c8-share-allowlist.md
@@ -1,0 +1,261 @@
+# Cluster 8 — Share Server Block-State Allowlist (BH-031)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Solo subagent, smallest cluster. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Prevent anonymous share-link holders from persisting arbitrary state to non-todo blocks.
+
+**Architecture:** In `server/share_server.go`'s `handleBlockStateUpdate`, add a block-type allowlist (`{"todos": true}`) after the existing note/block-membership checks. Non-matching types return 403.
+
+**Tech Stack:** Go, net/http, existing share-server test scaffolding.
+
+**Worktree branch:** `bugfix/c8-share-allowlist`
+
+---
+
+## File structure
+
+**Modified:**
+- `server/share_server.go` — block-type allowlist in `handleBlockStateUpdate`
+
+**Created:**
+- `server/api_tests/share_server_block_state_allowlist_test.go`
+
+---
+
+## Task 1: Failing API test
+
+**Files:**
+- Create: `server/api_tests/share_server_block_state_allowlist_test.go`
+
+- [ ] **Step 1: Find the existing share-server test patterns**
+
+```bash
+grep -rn "share_server\|ShareServer\|handleBlockStateUpdate\|shareToken" server/api_tests/ | head -20
+```
+
+Check whether an existing test file already seeds a shared note with a specific block type. Reuse the seeding helper if present; otherwise follow the test patterns in `share_server.go` itself.
+
+- [ ] **Step 2: Write the failing test**
+
+```go
+package api_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mahresources/models"
+)
+
+func TestShareBlockState_RejectsNonTodoBlocks(t *testing.T) {
+	tc := SetupTestEnv(t)
+	shareRouter, shareBaseUrl := setupShareServer(t, tc) // existing helper or equivalent
+	_ = shareBaseUrl
+
+	// Create a note and share it.
+	note := tc.CreateDummyNote("bh031-note")
+	token := tc.ShareNote(note.ID) // helper; or construct via API
+
+	// Add a gallery block to the note.
+	galleryContent, _ := json.Marshal(map[string]any{"resourceIds": []int{}})
+	gallery := &models.NoteBlock{
+		NoteID:  note.ID,
+		Type:    "gallery",
+		Content: string(galleryContent),
+	}
+	require.NoError(t, tc.DB.Create(gallery).Error)
+
+	// Attempt to write state to the gallery block via the share server.
+	stateBody, _ := json.Marshal(map[string]any{"layout": "list", "injected": true})
+	url := fmt.Sprintf("/s/%s/block/%d/state", token, gallery.ID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(stateBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	shareRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"BH-031: gallery block state write via share token must be rejected with 403")
+}
+
+func TestShareBlockState_AllowsTodoBlocks(t *testing.T) {
+	tc := SetupTestEnv(t)
+	shareRouter, _ := setupShareServer(t, tc)
+
+	note := tc.CreateDummyNote("bh031-note-todo")
+	token := tc.ShareNote(note.ID)
+
+	todosContent, _ := json.Marshal(map[string]any{"items": []map[string]any{{"id": "t1", "checked": false}}})
+	todos := &models.NoteBlock{NoteID: note.ID, Type: "todos", Content: string(todosContent)}
+	require.NoError(t, tc.DB.Create(todos).Error)
+
+	newState := []byte(`{"items":[{"id":"t1","checked":true}]}`)
+	url := fmt.Sprintf("/s/%s/block/%d/state", token, todos.ID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(newState))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	shareRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code,
+		"todos block state write must still succeed")
+}
+```
+
+**Helper functions**
+
+Before writing the test body above, grep for existing equivalents:
+
+```bash
+grep -rn "setupShareServer\|shareRouter\|ShareNote\|shareToken\|ShareServer" server/api_tests/ server/*.go | head -20
+```
+
+If a share-server test harness already exists (look in `server/api_tests/` for any file with `share` in the name), use it. Otherwise add these helpers to `api_test_utils.go`:
+
+```go
+// Returns the share server's http.Handler and a fake base URL for testing.
+func setupShareServer(t *testing.T, tc *TestContext) (http.Handler, string) {
+    srv := server.NewShareServer(tc.AppCtx) // actual constructor name per server/share_server.go
+    return srv.Handler(), "http://127.0.0.1:18383"
+}
+
+// Creates a share token for a note via the primary API.
+func (tc *TestContext) ShareNote(noteID uint) string {
+    form := url.Values{}
+    form.Set("NoteId", fmt.Sprintf("%d", noteID))
+    rr := tc.MakeFormRequest(http.MethodPost, "/v1/note/share", form)
+    if rr.Code != http.StatusOK {
+        t := tc.AppCtx
+        _ = t
+        panic(fmt.Sprintf("ShareNote failed: HTTP %d body=%s", rr.Code, rr.Body.String()))
+    }
+    var body map[string]any
+    json.Unmarshal(rr.Body.Bytes(), &body)
+    token, _ := body["token"].(string)
+    if token == "" {
+        token, _ = body["shareToken"].(string) // fallback naming
+    }
+    return token
+}
+```
+
+Substitute the actual `NewShareServer` constructor name found in `server/share_server.go` (likely `NewShareServer(ctx)` or `server.CreateShareServer(...)` — grep to confirm).
+
+- [ ] **Step 3: Run 3× — expect fail (gallery state write currently returns 200)**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestShareBlockState -v -count=3
+```
+
+Expected: 3× FAIL on the gallery case (status 200 instead of 403). The todo case may already pass.
+
+## Task 2: Add the allowlist check
+
+**Files:**
+- Modify: `server/share_server.go:131-173` (inside `handleBlockStateUpdate`)
+
+- [ ] **Step 1: Read current handler**
+
+```bash
+cat server/share_server.go | sed -n '125,180p'
+```
+
+- [ ] **Step 2: Add the block-type check after the note/block-membership validation**
+
+```go
+// server/share_server.go, inside handleBlockStateUpdate, after resolving `note`
+// and before calling UpdateBlockStateFromRequest:
+var allowedStateTypes = map[string]bool{
+    "todos": true,
+    // BH-031: todos is the only block type intended for share-side state writes.
+    // Future: expose specific calendar view-state if needed, via explicit opt-in.
+}
+
+var targetBlock *models.NoteBlock
+for i := range note.Blocks {
+    if note.Blocks[i].ID == blockId {
+        targetBlock = &note.Blocks[i]
+        break
+    }
+}
+if targetBlock == nil || !allowedStateTypes[targetBlock.Type] {
+    http.Error(w, "Block type does not allow share-token state writes", http.StatusForbidden)
+    return
+}
+```
+
+Ensure this check runs AFTER the token→note resolution (preventing type-confusion probes from revealing block-existence info on invalid tokens), and BEFORE any state-write operation.
+
+- [ ] **Step 3: Run tests 3× to verify pass**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run TestShareBlockState -v -count=3
+```
+
+Expected: PASS all 3 runs.
+
+- [ ] **Step 4: Run full share-server test set to confirm no regression**
+
+```bash
+go test --tags 'json1 fts5' ./server/api_tests/ -run '(?i)share' -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/share_server.go server/api_tests/share_server_block_state_allowlist_test.go
+git commit -m "fix(share): BH-031 — block-type allowlist on share-token state writes (todos only)"
+```
+
+---
+
+## Cluster PR gate
+
+- [ ] **Step 1: Full Go**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+- [ ] **Step 2: Rebase + full E2E + Postgres**
+
+- [ ] **Step 3: Open PR, self-merge**
+
+```bash
+gh pr create --title "fix(share): BH-031 — block-state write allowlist" --body "$(cat <<'EOF'
+Closes BH-031.
+
+## Changes
+
+- `server/share_server.go` — `handleBlockStateUpdate` now resolves the target block's type after note/ownership checks and requires it to be in the `{todos}` allowlist. Non-matching types return 403.
+
+## Tests
+
+- Go API: ✓ gallery-block state write via share token → 403; todos-block state write → 200. Pass 3× pre red / post green.
+- Full Go suite: ✓
+- Full E2E: ✓
+- Postgres: ✓
+
+## Security note
+
+Previously, any holder of a share token could persist arbitrary JSON state to any block type in a shared note. Impact was bounded to the block's `state` column (not content) but represented vandalism and integrity risk.
+
+## Bug-hunt-log update
+
+Post-merge: BH-031 → Fixed / closed.
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+Then master plan Step F.

--- a/docs/superpowers/plans/2026-04-22-bug-backlog-master.md
+++ b/docs/superpowers/plans/2026-04-22-bug-backlog-master.md
@@ -1,0 +1,224 @@
+# Bug-Backlog Cleanup — Master Orchestration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute each cluster plan one at a time. Each cluster is a separate worktree + PR. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 13 Major+Medium bugs in `tasks/bug-hunt-log.md` as 8 merged PRs.
+
+**Architecture:** File-location clustered bug fixes. Each cluster runs in its own git worktree off `master`. TDD per bug with 3× determinism checks. Self-merge on green. Autonomous end-to-end.
+
+**Tech Stack:** Go 1.21+ (build tags `json1 fts5`), Gorilla Mux, Pongo2, Alpine.js, Playwright E2E, SQLite + Postgres.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-22-bug-backlog-triage-design.md`
+
+---
+
+## Cluster Index (execution order)
+
+| # | Plan file | Bugs | Dependency |
+|---|---|---|---|
+| 1 | `2026-04-22-bug-backlog-c1-error-hygiene.md` | BH-P05, BH-019 | none |
+| 2 | `2026-04-22-bug-backlog-c2-form-ux.md` | BH-006, BH-009 | none |
+| 3 | `2026-04-22-bug-backlog-c3-image-hashing.md` | BH-011 → BH-018 | internal: BH-011 before BH-018 |
+| 4 | `2026-04-22-bug-backlog-c4-deletion-cascade.md` | BH-020, BH-024 | none |
+| 5 | `2026-04-22-bug-backlog-c5-jobs-ui-a11y.md` | BH-025, BH-026, BH-028 | none |
+| 6 | `2026-04-22-bug-backlog-c6-block-editor-a11y.md` | BH-027 | none |
+| 7 | `2026-04-22-bug-backlog-c7-alt-fs.md` | BH-023 | none |
+| 8 | `2026-04-22-bug-backlog-c8-share-allowlist.md` | BH-031 | none |
+
+Execute in the order listed. Each cluster ends with a merge to `master`.
+
+---
+
+## Pre-flight (before Cluster 1)
+
+- [ ] **Step 1: Confirm clean master baseline**
+
+```bash
+cd /Users/egecan/Code/mahresources
+git fetch origin
+git checkout master
+git pull --ff-only
+git status --short  # only pre-existing untracked tasks/ and modified config files allowed
+```
+
+Expected: `master` is up-to-date. Any uncommitted changes in user's working copy stay untouched.
+
+- [ ] **Step 2: Confirm full test suite is green on baseline**
+
+```bash
+go test --tags 'json1 fts5' ./...
+```
+
+Expected: PASS. If any pre-existing failures, STOP and escalate — cluster tests can't be trusted on a red baseline. Do NOT "fix while you're at it" — that's out of scope and must be escalated.
+
+- [ ] **Step 3: Confirm Docker is running (for final Postgres gate)**
+
+```bash
+docker info | head -5
+```
+
+Expected: Docker Desktop / daemon responding. If not, note that final Postgres gate will be deferred, but clusters can still proceed.
+
+---
+
+## Per-cluster execution template (applied to each of C1–C8)
+
+For **each** cluster plan in order:
+
+- [ ] **Step A: Create isolated worktree**
+
+Use `superpowers:using-git-worktrees` skill. Branch name matches the cluster's plan (e.g. `bugfix/c1-error-hygiene`). Worktree path under `../mahresources-worktrees/<branch>`.
+
+- [ ] **Step B: Execute the cluster plan**
+
+Work through every task in the cluster plan's file. Each task has its own TDD cycle (fail 3×, fix, pass 3×).
+
+- [ ] **Step C: Cluster-level test gate**
+
+```bash
+cd <worktree>
+go test --tags 'json1 fts5' ./...
+```
+
+Expected: PASS. If fail, diagnose and fix within the cluster (do NOT proceed to next cluster).
+
+Additionally run the cluster's targeted E2E surface:
+
+```bash
+cd <worktree>/e2e
+npm run test:with-server -- --grep "<cluster-tag>"
+```
+
+- [ ] **Step D: Rebase on latest master, run full suite**
+
+```bash
+cd <worktree>
+git fetch origin
+git rebase origin/master
+go test --tags 'json1 fts5' ./...
+cd e2e && npm run test:with-server:all
+cd ../ && go test --tags 'json1 fts5 postgres' ./mrql/... ./server/api_tests/... -count=1
+cd e2e && npm run test:with-server:postgres
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step E: Open PR, verify all gates in PR body, self-merge**
+
+```bash
+cd <worktree>
+gh pr create --title "fix(area): BH-<IDs> — <short>" --body "$(cat <<'EOF'
+Closes BH-<id> ...
+[see each cluster plan for full body]
+EOF
+)"
+gh pr merge --merge --delete-branch
+```
+
+- [ ] **Step F: Update bug-hunt-log and clean up**
+
+Move merged BH-IDs from the active section to the "Fixed / closed pre-existing" section of `tasks/bug-hunt-log.md` with merge SHA + date. Commit directly to master:
+
+```bash
+git checkout master
+git pull
+# edit tasks/bug-hunt-log.md
+git add tasks/bug-hunt-log.md
+git commit -m "chore(bughunt): mark BH-<IDs> fixed (<cluster>, merged <sha>)"
+git push
+```
+
+Then delete the worktree:
+
+```bash
+git worktree remove ../mahresources-worktrees/bugfix/c<N>-<slug>
+```
+
+- [ ] **Step G: Proceed to next cluster**
+
+No user check-in. Start Step A for the next cluster.
+
+---
+
+## Final gate (after Cluster 8 merges)
+
+- [ ] **Step 1: Checkout fresh master**
+
+```bash
+cd /Users/egecan/Code/mahresources
+git checkout master
+git pull --ff-only
+```
+
+- [ ] **Step 2: Full regression sweep**
+
+```bash
+go test --tags 'json1 fts5' ./...
+cd e2e && npm run test:with-server:all
+cd .. && go test --tags 'json1 fts5 postgres' ./mrql/... ./server/api_tests/... -count=1
+cd e2e && npm run test:with-server:postgres
+```
+
+Expected: ALL PASS on new `master`.
+
+- [ ] **Step 3: Completion report**
+
+Write summary to `tasks/bug-backlog-cleanup-report.md` covering:
+
+- 8 merged PR SHAs and URLs
+- All 13 BH-IDs closed (with merge SHA per bug)
+- Total new tests added (count by type: Go unit, Go API, Playwright E2E)
+- Any tests that flaked and were deflaked (with root cause)
+- Any bugs escalated (should be zero in nominal case)
+- Any new bugs discovered and logged (with BH-IDs for unverified entries)
+- Total wall-clock elapsed
+
+Commit report to master, announce completion to user.
+
+---
+
+## Rollback procedure (escalation-only)
+
+If a cluster PR is merged and subsequent regression sweep finds a regression introduced by that cluster:
+
+- [ ] **Step 1: Revert the PR merge**
+
+```bash
+git checkout master
+git revert -m 1 <merge-sha>
+git commit -m "revert: <cluster name> due to <regression>"
+git push
+```
+
+- [ ] **Step 2: Reopen the bugs**
+
+Move affected BH-IDs back to the active section of `tasks/bug-hunt-log.md` with a note referencing the revert.
+
+- [ ] **Step 3: Escalate to user**
+
+This constitutes a Section 8.2 escalation in the design spec. Stop and ask the user for guidance before re-attempting.
+
+---
+
+## Inventory of tests to be added
+
+Running total across all clusters (rough pre-count; refine in each plan):
+
+- **C1:** 1 Go API test (BH-P05 extension) + 6 Go unit tests (BH-019, one per entity type) = **7 tests**
+- **C2:** 6 Playwright specs (BH-006, one per entity form) + 3 Go API tests (BH-006 JSON-path safety) + 3 Playwright specs (BH-009, required / pattern / type-mismatch) = **12 tests**
+- **C3:** 2 Go API tests (BH-011: rejected bad image, valid image accepted) + 2 Go unit tests (BH-018: solid-color rejection, near-dupe acceptance) = **4 tests**
+- **C4:** 4 Go API tests (BH-020, one per block type) + 1 Go API test (BH-024 err-translator) + 1 migration test = **6 tests**
+- **C5:** 3 Playwright specs (BH-025 reload, BH-026 completed-export link, BH-028 panel dialog + progressbar ARIA) = **3 tests**
+- **C6:** 1 Playwright spec (axe-core sweep of block editor) + 4 targeted assertions = **1 test file, 4 assertion blocks**
+- **C7:** 2 Go API tests (BH-023 multipart PathName, export/import round-trip) + 1 Playwright spec (storage select visible) = **3 tests**
+- **C8:** 1 Go API test (BH-031 block-type allowlist) = **1 test**
+
+**Grand total: ~36 tests added.**
+
+---
+
+## Notes on autonomy
+
+- Every cluster's plan file says "execute autonomously" and references the design spec's § 8 autonomy contract.
+- If a subagent hits a hard-stop condition (see design § 8.2), it pauses and escalates — not the orchestrator.
+- The orchestrator (this plan) simply sequences the clusters and gates the final regression sweep.

--- a/docs/superpowers/specs/2026-04-22-bug-backlog-triage-design.md
+++ b/docs/superpowers/specs/2026-04-22-bug-backlog-triage-design.md
@@ -1,0 +1,296 @@
+# Bug-Backlog Cleanup — Triage & Fix Strategy
+
+**Date:** 2026-04-22
+**Status:** Design approved, ready for per-cluster implementation plans
+**Source backlog:** `tasks/bug-hunt-log.md` (iters 1–14)
+**Scope:** 13 of 34 active bugs — all Major and Medium severity
+
+## 1. Summary
+
+Drive the Major + Medium half of the bug-hunt backlog to completion as 8 file-location-clustered pull requests, executed autonomously end-to-end once the plan is approved. Each bug gets a failing test first (TDD), each test is checked for determinism (3× pass before fix, 3× pass after), each cluster is isolated in its own worktree, and each PR self-merges the moment its tests go green. User approval is paid up front; execution runs without check-ins.
+
+## 2. Context
+
+The bug-hunt loop has accumulated 34 active findings over 14 iterations. Clusters of related bugs — form-data-loss across 6 entities, silent validation in the schema editor, a11y gaps across block editor + jobs panel, a stale-reference class across 4 block types — are ripe for one-shot fixes at their shared root cause. Cosmetic items (BH-001, 002, 017) and feature-gaps (BH-005, 012, 013, 014, 016, 021, 022, 030, 032–038) are out of scope for this pass and stay in the log.
+
+Pre-existing plan drafts under `tasks/plan-group-{a,b,c}.md` cover earlier bugs that are now fixed (per iter-7 verification); they are not used in this effort.
+
+## 3. Scope — 13 bugs
+
+| BH-ID | Severity | One-line |
+|---|---|---|
+| BH-P05 | Major | `.json` error responses leak full server config |
+| BH-006 | Major | Native create/edit forms blow up to a bare error page on server-side validation failure |
+| BH-009 | Major | Schema-editor form mode: required/pattern violations show no error message |
+| BH-011 | Major | Image ingestion accepts truncated uploads as valid images (W=0, H=0) |
+| BH-027 | Major | Block-editor a11y: 4 WCAG-A violations (2 axe-critical) |
+| BH-028 | Major | Download cockpit a11y: 3 WCAG-A/AA violations |
+| BH-018 | Medium | Perceptual-hash false positives on uniform/solid-color images (DHash=0 collisions) |
+| BH-019 | Medium | Entity names accept NUL bytes, RTL override, embedded newlines |
+| BH-020 | Medium | 4 block types keep dangling references after target deletion |
+| BH-023 | Medium | Alt-FS feature half-implemented across UI, multipart API, and export/import manifest |
+| BH-025 | Medium | `adminExport` loses all job tracking on page reload |
+| BH-026 | Medium | Download cockpit shows blank title + no download link for completed group-export jobs |
+| BH-031 | Medium | Share server block-state write endpoint accepts any block type, not just `todos` |
+
+BH-024 (dangling-query 500-vs-404) is picked up inside cluster 4 while we're already in the deletion-cascade code, though it's technically minor severity.
+
+## 4. Approach — file-location clustering
+
+Bugs are grouped by the files the fix touches, not by severity or user journey. This maximizes worktree isolation (parallel subagents inside a cluster don't fight each other) and produces natural PR review boundaries (each PR is one coherent file neighborhood).
+
+Cluster order favors ROI (highest-severity clusters first). There is only one hard dependency:
+
+- **BH-011 before BH-018 inside Cluster 3** — BH-018's AHash test presumes valid-image ingestion, which BH-011's fix enforces.
+
+All other clusters are order-independent; they run sequentially only because the chosen execution model is "sequential between clusters, parallel within." C1 and C2 touch partially overlapping error surfaces (C1's `renderJSONError` covers `.json` routes, C2's PRG covers HTML routes), so after both land the error surface is uniformly clean, but either can land first without blocking the other.
+
+## 5. Clusters
+
+### Cluster 1 — Error hygiene
+**Bugs:** BH-P05, BH-019
+**Parallelism:** 2 subagents (BH-P05 and BH-019 touch disjoint files)
+**Primary files:**
+- `server/error_handler.go` (or equivalent) — new `renderJSONError(w, status, msg)` helper
+- `server/template_handlers/` — replace context-dump JSON encoding on every `.json` error path
+- A new sanitizer helper (e.g. `application_context/validation/entity_name.go`) — single `sanitizeEntityName(name string) (string, error)` used by tag/group/note/resource/noteType/category create/update handlers
+
+**Fix sketches:**
+- **BH-P05:** `renderJSONError` returns only `{"error": "...", "status": N}`. Audit every route that currently returns a `.json` error variant to ensure they use the helper. Evidence target: `curl -isS /resource.json?id=abc` body shrinks from 1214 bytes of `_appContext.Config.*` to the minimal error JSON.
+- **BH-019:** Reject on create/update: any `\x00`, any Unicode C0 control char except `\t`, any directional override (`U+202A`–`202E`, `U+2066`–`2069`), any CR/LF. Return 400 with a clear message. Unit test each class.
+
+### Cluster 2 — Form-UX systemic
+**Bugs:** BH-006, BH-009
+**Parallelism:** 2 subagents (backend form flow vs. frontend schema editor)
+**Primary files:**
+- `server/api_handlers/*.go` — resource, group, note, category, tag, noteType create + edit handlers
+- `server/template_handlers/` — the POST-Redirect-Get response when `Accept: text/html`
+- `src/schema-editor/modes/form-mode.ts` — `_renderStringInput` / `_renderNumberInput` `onBlur` + `form submit` validation
+
+**Fix sketches:**
+- **BH-006:** On HTML-accepting requests that 400, 302 back to `/<entity>/new` (or `/<entity>/edit?id=…`) with (a) form fields re-encoded as query params and (b) `error=<msg>`. Keep JSON 400 for API clients. Template re-populates fields from the query string. `bulkSelection.js:171-192` is the async precedent to reference but not the chosen path (server-rendered PRG is lower-surface).
+- **BH-009:** In `onBlur`, after the existing min/max branch, check `input.validity.valueMissing`, `patternMismatch`, `typeMismatch`, `tooShort`, `tooLong`, `stepMismatch` and set `#field-<name>-error` + `aria-invalid="true"`. Hook the same routine into `form.addEventListener('submit', …)` so errors surface on Save even when the user never blurs the field.
+
+### Cluster 3 — Image ingestion + hashing
+**Bugs:** BH-011, BH-018
+**Parallelism:** 2 subagents, but BH-011 must complete before BH-018's test can rely on W/H > 0.
+**Primary files:**
+- `application_context/resource_media_context.go` — ingestion decode + dimension extraction
+- `hash_worker/worker.go` — AHash + DHash combination
+
+**Fix sketches:**
+- **BH-011:** In the image-resource ingestion flow, if `image.Decode` errors OR `Dx()==0 || Dy()==0`, reject with 400 `"Uploaded file is not a valid image (failed to decode)"`. Ship with a separate one-shot audit SQL that lists existing `ContentType LIKE 'image/%' AND (Width=0 OR Height=0)` rows for the operator to review.
+- **BH-018:** In `findAndStoreSimilarities`, when `DHash == 0` (or Hamming ≤ very low thr1), require `AHash` Hamming also ≤ a separate thr2 before recording the pair. New flag `--hash-ahash-threshold` (default e.g. 5). Unit test: two solid colors (lightblue, orange, 300×300 PNG) should NOT be recorded as similar; two actual near-dupes should still record.
+
+### Cluster 4 — Block-content deletion cascade
+**Bugs:** BH-020 (+ BH-024 as an incidental fix)
+**Parallelism:** 1 subagent (all changes are in the same delete-handler surface)
+**Primary files:**
+- `application_context/resource_context.go` delete path, `group_context.go` delete path, `mrql_context.go` saved-query delete path
+- A new one-shot migration under `application_context/migrations/` that scrubs existing orphans
+- `src/components/blocks/gallery.js`, `references.js`, `table.js` for graceful-degrade rendering (calendar already handles it)
+- `server/api_handlers/block_table_handler.go` for BH-024's err-translator outlier
+
+**Fix sketches:**
+- **BH-020:** On delete of a resource / group / saved-query, walk `note_blocks` and scrub matching IDs from `content.resourceIds[]`, `content.groupIds[]`, `content.calendars[].source.resourceId`, `content.queryId`. SQLite: `json_each` + `json_remove` + `json_set`. Postgres: `jsonb_array_elements` + `jsonb_set`. One-shot migration does the same scan on boot for pre-existing orphans. Gate with new `SKIP_BLOCK_REF_CLEANUP=1` flag to mirror the existing `SKIP_VERSION_MIGRATION` escape hatch for large DBs.
+- **BH-024:** wrap the inner query fetch in the table-block handler with `statusCodeForError` (same helper used across `/v1/note`, `/v1/group`, etc.) so `gorm.ErrRecordNotFound` becomes 404, not 500.
+- **UI graceful-degrade:** each affected block component shows `"Resource unavailable"` / `"Group unavailable"` / `"Query unavailable"` on 404 from its metadata fetch.
+
+### Cluster 5 — Jobs UI + a11y
+**Bugs:** BH-025, BH-026, BH-028
+**Parallelism:** 1 subagent (the three bugs touch overlapping files — parallel subagents would step on each other)
+**Primary files:**
+- `src/components/adminExport.js`
+- `src/components/downloadCockpit.js`
+- `templates/partials/downloadCockpit.tpl`
+- `templates/adminExport.tpl`
+
+**Fix sketches:**
+- **BH-025:** `adminExport.init()` subscribes to the jobs SSE stream (same pattern as `downloadCockpit.connect()`) and rehydrates `this.job` from `localStorage` (key: most-recent submitted jobId) on reload. `x-show="job"` then re-shows the progress panel.
+- **BH-026:** Extend `getJobTitle()` to fall back to `job.name` / "Group export" when `job.url === ""`. New template branch in `downloadCockpit.tpl`: when `source === 'group-export'` and `resultPath`, render `<a href="/v1/exports/{jobId}/download">` with a filename derived from `resultPath`.
+- **BH-028:**
+  - Panel: `role="dialog" aria-modal="true" aria-labelledby="jobs-panel-heading"`, `$watch('isOpen', ...)` moves focus into the panel on open, restores focus to the trigger on close.
+  - Progress bars: `role="progressbar" :aria-valuenow="..." aria-valuemin="0" aria-valuemax="100" :aria-label="..."`.
+  - Connection status: `role="img" :aria-label="'Connection status: ' + connectionStatus"` or sr-only span.
+
+### Cluster 6 — Block-editor a11y
+**Bugs:** BH-027
+**Parallelism:** 1 subagent
+**Primary files:**
+- `templates/partials/blockEditor.tpl`
+- `src/components/blockEditor.js`
+
+**Fix sketches:**
+- Gallery `<img>`: `:alt="getResourceName(resId) || 'Resource ' + resId"`.
+- Heading-level select: `aria-label="Heading level"`.
+- Move-up/down/delete icon buttons: `:aria-label="'Move block ' + (index+1) + ' up'"` etc.
+- Add-block picker trigger: `:aria-expanded="addBlockPickerOpen.toString()" aria-haspopup="listbox" aria-controls="add-block-listbox"`; container: `role="listbox" aria-label="Block types"` + roving tabindex + Arrow-key handlers.
+
+### Cluster 7 — Alt-FS round-trip completion
+**Bugs:** BH-023
+**Parallelism:** 1 subagent (three layers, serial inside the cluster)
+**Primary files:**
+- `archive/manifest.go` — `ResourcePayload` gets optional `storage_location`
+- `models/query_models/resource_query.go` — `ResourceCreator` gets `PathName`
+- `application_context/resource_context.go` — thread `PathName` through `AddResource`
+- `templates/createResource.tpl` — storage `<select>` populated from `config.altFileSystems`
+
+**Fix sketches:**
+- **Manifest:** add optional field, NO `schema_version` bump (unknown keys are silently ignored per the stable-contract rule, so adding optional ones is forward-compat). Exporter sets it when non-empty; importer applies it when present; absent → default fs.
+- **Multipart API:** `ResourceCreator.PathName` wires the hint through `AddResource`.
+- **UI:** `<select>` appears only when `config.altFileSystems` is non-empty.
+
+### Cluster 8 — Share server block-state allowlist
+**Bugs:** BH-031
+**Parallelism:** 1 subagent
+**Primary files:**
+- `server/share_server.go`
+
+**Fix sketch:** In `handleBlockStateUpdate`, resolve the target block type after the existing note/block-membership checks. Allowlist `{"todos": true}` (add `"calendar": true` if view-state persistence is desired; the PR decides based on current behavior). Non-matching types return 403.
+
+## 6. Testing discipline
+
+### 6.1 Per-bug TDD flow
+
+Every bug, without exception:
+
+1. Write the failing test **first**. E2E (Playwright) for UI-visible symptoms; Go unit for backend-only; API-level test for server behavior that has no UI surface.
+2. Run the new test 3× in isolation **before** writing the fix (`--retries=0 --repeat-each=3` or equivalent). All 3 runs must fail **with the symptom the bug describes** (e.g., the leaked config field appears in response, the expected error message is missing, the block still holds the dangling ID). A test that fails for a framework / selector / env reason is not a red test — it is a broken test and must be repaired before proceeding.
+3. Write the fix.
+4. Re-run the same test 3× in isolation. All 3 runs must pass.
+5. Only then commit both the test and the fix (one commit with both, or two adjacent commits, consistent within the cluster).
+
+### 6.2 Anti-flakiness hard rules
+
+For every test written in this effort:
+
+- **No `page.waitForTimeout`, no `sleep`, no hard-coded delays.** Use `expect.poll`, `expect.toHaveText`, `waitFor` with explicit conditions.
+- **No reliance on animation timing.** Assert on final state, not transitions.
+- **No reliance on global DB state or ID ordering.** Always pin tests to unique names the test itself creates; never assert on "the first row" or a hardcoded ID.
+- **Ephemeral server per suite** via the existing `test:with-server` script. Never hit a shared dev server.
+- **SQLite parallelism capped at `-max-db-connections=2`** (CLAUDE.md-documented pattern).
+- **SSE / job tests:** poll for terminal state (`completed` / `failed`) with an explicit budget, never a fixed wait.
+- **Hash-worker tests:** seed DB directly or use a synchronous-trigger test path, never sleep on `HASH_POLL_INTERVAL`.
+- **Randomized and parallel ordering:** the new tests must survive both Playwright's parallel mode and `--workers=1`. Verify once per cluster by running the new tests in both modes.
+
+### 6.3 Test gates per cluster (PR open)
+
+- `go test --tags 'json1 fts5' ./...` passes locally.
+- Cluster's new tests pass 3× consecutively after the fix.
+- Targeted E2E for the surfaces the cluster touches passes once.
+
+### 6.4 Test gates before merge
+
+- Full E2E browser suite against an ephemeral server passes (`cd e2e && npm run test:with-server`).
+- Full E2E CLI suite passes (`cd e2e && npm run test:with-server:cli`).
+- Postgres suite passes (`go test --tags 'json1 fts5 postgres' ./mrql/... ./server/api_tests/... -count=1 && cd e2e && npm run test:with-server:postgres`).
+
+## 7. Workflow — worktrees, branches, PRs, merges
+
+- Each cluster: a fresh worktree off the latest `master` using the `superpowers:using-git-worktrees` skill.
+- Branch pattern: `bugfix/c<N>-<slug>` (e.g., `bugfix/c1-error-hygiene`, `bugfix/c4-block-deletion-cascade`).
+- Commits: one commit per bug inside the cluster, or per logical change if a bug needs more than one (test+fix pair is fine in one commit). Conventional commits: `fix(area): BH-NNN — short description`.
+- PR title: `fix(area): BH-<IDs> — short`.
+- PR body template:
+  ```
+  Closes BH-<id>, BH-<id>.
+
+  ## Changes
+  - ...
+
+  ## Tests
+  - Unit: ✓
+  - E2E (browser): ✓ (cluster-targeted)
+  - E2E (CLI): ✓ (cluster-targeted)
+  - Postgres: ✓
+  - New tests pass 3× consecutively
+  - Run in both parallel and `--workers=1` modes
+
+  ## Evidence
+  - `tasks/bug-hunt-evidence/...` links
+  ```
+- Merge strategy: **merge commit** (preserves per-bug commit history in the cluster branch). Rebase on latest `master` immediately before the merge to avoid accidental drift.
+- Auto-merge: **I merge when tests are green.** No user approval required per cluster.
+- Post-merge: update `tasks/bug-hunt-log.md` to move merged BH-IDs to the "Fixed / closed" table with merge SHA + date, delete the worktree.
+
+## 8. Autonomy contract
+
+### 8.1 What I do without asking
+
+- Create and destroy worktrees per cluster.
+- Write and commit tests + fixes.
+- Rebase on `master` and merge my own PRs when tests pass.
+- Update `tasks/bug-hunt-log.md`.
+- Choose between multiple reasonable implementations when the design leaves latitude.
+- Re-run flaky tests up to the 3× budget; deflake if the budget is exceeded.
+- Generate and commit OpenAPI spec regenerations if the API surface changes (via `go run ./cmd/openapi-gen`).
+
+### 8.2 What I escalate (rare — expected zero in nominal case)
+
+- A fix requires a breaking `archive/manifest.go` schema_version bump (current plan avoids this).
+- A bug's fix turns out to need architecture-level changes beyond spec scope.
+- A fix introduces >15% regression in test-suite wall-clock.
+- New severe bugs are discovered mid-fix that block the current cluster's acceptance.
+- Operations outside my worktree (force-push to master, rewriting shared git history, `git reset --hard` against shared refs).
+
+### 8.3 Hard stops (never done autonomously)
+
+- No `git push --force` to master.
+- No deletion of user files or branches outside my own worktrees.
+- No exfiltration of secrets to external services.
+- No skipping pre-commit hooks (`--no-verify`, `--no-gpg-sign`).
+
+## 9. Cross-cutting risks
+
+- **Archive-manifest contract (C7):** `archive/manifest.go` is a stable public contract per CLAUDE.md. The design deliberately adds `storage_location` as an optional field without bumping `schema_version` — readers silently ignore unknown keys (forward-compat rule), so this is safe. If the implementation reveals a reason a bump is required, the cluster pauses and escalates.
+- **C4 migration on large DBs:** the one-shot block-reference cleanup could be expensive on deployments with "millions of resources" (CLAUDE.md). Gated behind `SKIP_BLOCK_REF_CLEANUP=1` so operators can defer.
+- **Test-DB pollution:** per iter-14 notes, the test DB already contains hundreds of `[bughunt-*]` entities and resources 87/107/115 with W=0/H=0. Every test written must assert only on rows the test itself creates; no global counts, no "first row" assertions.
+- **C2 BH-006 surface breadth:** 6+ entities × (create + edit) paths is the broadest surface in the backlog. Budget this cluster as the largest; accept that it may take the most wall clock.
+- **C5 single-subagent pacing:** Cluster 5 bundles three bugs in one subagent because the files overlap. If the subagent thrashes, the fallback is to split the cluster into C5a (BH-028 a11y, template/JS additions) and C5b (BH-025 + BH-026, logic changes), executed serially in the same worktree.
+
+## 10. Definition of done — per cluster
+
+1. Every bug in the cluster has a pre-fix failing test, now passing, with 3× determinism confirmed both pre- and post-fix.
+2. `go test --tags 'json1 fts5' ./...` passes.
+3. Cluster's targeted E2E (browser + CLI as relevant) passes.
+4. PR open with full body (including the 3× determinism note).
+5. Rebased on latest `master`.
+6. Full E2E browser + CLI + Postgres suite passes on the rebased branch.
+7. Merged to `master` (I do this).
+8. `tasks/bug-hunt-log.md` updated.
+9. Worktree deleted.
+
+## 11. Definition of done — whole effort
+
+1. All 8 clusters merged to `master`.
+2. One final full-suite regression sweep against new `master`: Go unit + E2E browser + E2E CLI + Postgres all pass.
+3. All 13 BH-IDs appear in the "Fixed / closed" section of `tasks/bug-hunt-log.md` with merge SHAs.
+4. One completion report summarizing: merged PRs, tests added, flaky tests observed and deflaked, any bugs escalated, any new bugs discovered and logged.
+
+## 12. Pre-execution checklist (clear-everything-up-front)
+
+Before the first worktree is created:
+
+1. **Files each cluster will touch** — listed in § 5, to be refined per-cluster in the implementation plan.
+2. **New tests** — listed per bug in the implementation plan, with a 1-line purpose each.
+3. **New config flags / env vars:**
+   - `--hash-ahash-threshold` / `HASH_AHASH_THRESHOLD` (C3, BH-018, default 5)
+   - `SKIP_BLOCK_REF_CLEANUP` (C4, migration escape hatch)
+   - No others planned.
+4. **Repo-state cleanup:** each cluster's worktree starts from latest `master`. Uncommitted state in the user's primary working copy is left untouched. `test.db-shm/wal` files are ephemeral and owned by test runs.
+5. **Wall-clock estimates:** to be attached per cluster in the implementation plan.
+6. **Reporting cadence:** one final report at the end. No per-cluster check-ins.
+
+## 13. Out of scope (explicit)
+
+- 21 active bugs not in the 13-bug list (cosmetic, minor, feature-gap) — stay in the log for a future pass.
+- Cosmetic database-state hygiene (removing `[bughunt-*]` test pollution) — noted in log iter-14 follow-up; operator decision.
+- Share-token expiry (BH-035 follow-up suggestion) — design gap, not a bug; needs its own brainstorm.
+- Primary-server security-headers audit (BH-032 extension) — queued, not scoped here.
+- The existing `tasks/plan-group-{a,b,c}.md` drafts — superseded by this document.
+
+## 14. Handoff
+
+On approval, I invoke `superpowers:writing-plans` to produce per-cluster implementation plans (one plan per cluster, each with file-level changes, test-level changes, and a review checkpoint structure compatible with the autonomy contract).
+
+Once those plans are written and cross-checked, the autonomous execution phase begins.

--- a/server/api_tests/entity_name_control_chars_test.go
+++ b/server/api_tests/entity_name_control_chars_test.go
@@ -1,0 +1,83 @@
+package api_tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// BH-019: entity names must not accept NUL bytes, Unicode directional
+// overrides/isolates, or embedded newlines. These characters cause UI
+// spoofing, CSV/log corruption, and C-library truncation (e.g. ffmpeg
+// shelling to a path containing NUL).
+
+func TestTagCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-nul\x00byte")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "NUL-byte name must be rejected with 400, got body=%s", resp.Body.String())
+}
+
+func TestTagCreate_RejectsDirectionalOverrideInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19‮rotated")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "RTL override in name must be rejected, got body=%s", resp.Body.String())
+}
+
+func TestTagCreate_RejectsEmbeddedNewlineInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19\nwith newline")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "Newline in name must be rejected, got body=%s", resp.Body.String())
+}
+
+func TestTagCreate_AcceptsNormalName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-ordinary-tag-name")
+
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/tag", form)
+	assert.Equal(t, http.StatusOK, resp.Code, "Ordinary name must still succeed, got body=%s", resp.Body.String())
+}
+
+func TestGroupCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-group\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/group", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "got body=%s", resp.Body.String())
+}
+
+func TestNoteCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-note\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/note", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "got body=%s", resp.Body.String())
+}
+
+func TestCategoryCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-cat\x00null")
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/category", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "got body=%s", resp.Body.String())
+}
+
+func TestNoteTypeCreate_RejectsNullByteInName(t *testing.T) {
+	tc := SetupTestEnv(t)
+	form := url.Values{}
+	form.Set("Name", "bh19-nt\x00null")
+	// NoteType create route is /v1/note/noteType.
+	resp := tc.MakeFormRequest(http.MethodPost, "/v1/note/noteType", form)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "got body=%s", resp.Body.String())
+}

--- a/server/api_tests/json_error_leaks_appcontext_test.go
+++ b/server/api_tests/json_error_leaks_appcontext_test.go
@@ -1,0 +1,54 @@
+package api_tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// BH-P05: `.json` error responses must not leak `_appContext` / `_requestContext`.
+// Those keys serialize the entire server config (DbDsn, FfmpegPath, FileSavePath,
+// AltFileSystems, plugin manager, etc.) on any error-rendered .json route.
+
+func TestJsonErrorDoesNotLeakAppContext(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Non-existent id on .json route renders an error with a populated template context.
+	resp := tc.MakeRequest(http.MethodGet, "/resource.json?id=99999", nil)
+	assert.GreaterOrEqual(t, resp.Code, 400, "response should be an error status")
+
+	var body map[string]any
+	err := json.Unmarshal(resp.Body.Bytes(), &body)
+	require.NoError(t, err, "response should be valid JSON")
+
+	// These must NOT leak — they exposed full server config and nested context.
+	assert.NotContains(t, body, "_appContext", "_appContext must not leak in JSON error response")
+	assert.NotContains(t, body, "_requestContext", "_requestContext must not leak in JSON error response")
+
+	// Sanity: the user-facing error must still be present.
+	assert.Contains(t, body, "errorMessage", "errorMessage should be present in error response")
+}
+
+func TestJsonErrorDoesNotLeakAppContextAcrossEntities(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	for _, path := range []string{
+		"/note.json?id=99999",
+		"/group.json?id=99999",
+		"/tag.json?id=99999",
+		"/resource.json?id=99999",
+	} {
+		resp := tc.MakeRequest(http.MethodGet, path, nil)
+		assert.GreaterOrEqual(t, resp.Code, 400, "%s: expected error status", path)
+
+		var body map[string]any
+		err := json.Unmarshal(resp.Body.Bytes(), &body)
+		require.NoError(t, err, "%s: response should be valid JSON", path)
+
+		assert.NotContains(t, body, "_appContext", "%s: _appContext must not leak", path)
+		assert.NotContains(t, body, "_requestContext", "%s: _requestContext must not leak", path)
+	}
+}

--- a/server/template_handlers/render_template.go
+++ b/server/template_handlers/render_template.go
@@ -63,6 +63,8 @@ func RenderTemplate(templateName string, templateContextGenerator func(request *
 				// Internal/rendering fields (should not leak to JSON consumers)
 				"_pluginManager":     true,
 				"_statusCode":        true,
+				"_appContext":        true, // BH-P05: contains full MahresourcesConfig (DbDsn, FfmpegPath, FileSavePath, AltFileSystems, ...)
+				"_requestContext":    true, // BH-P05: nested Go request context
 				"currentPath":        true,
 				"pluginMenuItems":    true,
 				"menu":               true,


### PR DESCRIPTION
Closes BH-P05, BH-019.

## Changes

- `server/template_handlers/render_template.go` — add `_appContext` + `_requestContext` to JSON discard list. `.json` error responses no longer leak server config.
- `application_context/validation/entity_name.go` — new `SanitizeEntityName` helper rejects NUL bytes, C0/C1 controls (except `\t`), Unicode directional overrides (U+202A–U+202E, U+2066–U+2069), and embedded newlines.
- Wired into tag/group/note/resource/noteType/category create + update paths.

## Tests

- Unit: ✓ `application_context/validation/entity_name_test.go` (6 cases)
- API: ✓ `server/api_tests/json_error_leaks_appcontext_test.go` (2 cases)
- API: ✓ `server/api_tests/entity_name_control_chars_test.go` (8 cases)
- All new tests pass 3× consecutively (both pre-fix 3× red and post-fix 3× green verified)
- Full `go test ./...`: ✓
- Full E2E (browser + CLI): ✓ (1431 expected, 0 unexpected, 1 pre-existing flaky)
- Postgres: ✓ (1430 passed, 2 pre-existing flaky, 0 failed)

## Evidence of fix

- BH-P05: `curl -s http://localhost:8181/resource.json?id=abc | jq 'has("_appContext")'` → `false`
- BH-019: `POST /v1/tag name=bh-nul%00byte` → HTTP 400

## Bug-hunt-log update

Post-merge, both BH-P05 and BH-019 move from active to fixed in `tasks/bug-hunt-log.md`.