### PR TITLE
feat(altfs): BH-023 — alt-fs round-trip (UI + multipart + manifest)

### DIFF
--- a/application_context/apply_import.go
+++ b/application_context/apply_import.go
@@ -1331,6 +1331,11 @@ func (s *applyState) applyOneResource(tx *gorm.DB, exportID string, rp *archive.
 		CreatedAt:        rp.CreatedAt,
 		UpdatedAt:        rp.UpdatedAt,
 	}
+	// BH-023: restore alt-fs binding; empty string means default filesystem.
+	if rp.StorageLocation != "" {
+		sl := rp.StorageLocation
+		r.StorageLocation = &sl
+	}
 	if rp.GUID != "" {
 		guid := rp.GUID
 		r.GUID = &guid

--- a/application_context/context.go
+++ b/application_context/context.go
@@ -330,6 +330,13 @@ func (ctx *MahresourcesContext) PluginManager() *plugin_system.PluginManager {
 	return ctx.pluginManager
 }
 
+// RegisterAltFs adds an alternative filesystem under the given key. This is
+// used at startup (via NewMahresourcesContext from config) and in tests that
+// need to inject an in-memory alt-fs without going through disk paths.
+func (ctx *MahresourcesContext) RegisterAltFs(key string, fs afero.Fs) {
+	ctx.altFileSystems[key] = fs
+}
+
 // RunBeforePluginHooks executes before-hooks for the given event.
 // If no plugin manager is active, data is returned unmodified.
 func (ctx *MahresourcesContext) RunBeforePluginHooks(event string, data map[string]any) (map[string]any, error) {

--- a/application_context/export_context.go
+++ b/application_context/export_context.go
@@ -1584,6 +1584,10 @@ func (ctx *MahresourcesContext) loadResourcePayload(
 		Versions:         []archive.ResourceVersionPayload{},
 		Previews:         []archive.PreviewPayload{},
 	}
+	// BH-023: preserve the alt-fs key so import can restore storage binding.
+	if r.StorageLocation != nil && *r.StorageLocation != "" {
+		p.StorageLocation = *r.StorageLocation
+	}
 	p.GUID = ctx.ensureGUID("resources", r.ID, r.GUID)
 
 	if r.OwnerId != nil {

--- a/application_context/export_import_altfs_test.go
+++ b/application_context/export_import_altfs_test.go
@@ -1,0 +1,193 @@
+package application_context
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/spf13/afero"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"mahresources/archive"
+	"mahresources/constants"
+	"mahresources/download_queue"
+	"mahresources/models"
+)
+
+// noopSinkAltFS satisfies download_queue.ProgressSink for the alt-fs round-trip test.
+// Named differently from apply_import_test.go's noopSink to avoid redeclaration.
+type noopSinkAltFS struct{}
+
+func (noopSinkAltFS) SetPhase(string)              {}
+func (noopSinkAltFS) SetPhaseProgress(int64, int64) {}
+func (noopSinkAltFS) UpdateProgress(int64, int64)   {}
+func (noopSinkAltFS) AppendWarning(string)          {}
+func (noopSinkAltFS) SetResultPath(string)          {}
+
+var _ download_queue.ProgressSink = noopSinkAltFS{}
+
+// createContextWithAltFs creates a fresh isolated context that has an alt-fs
+// named "archival" backed by an in-memory filesystem.
+func createContextWithAltFs(t *testing.T, name string) (*MahresourcesContext, afero.Fs) {
+	t.Helper()
+
+	dsn := "file:" + name + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Query{},
+		&models.Resource{},
+		&models.ResourceVersion{},
+		&models.Note{},
+		&models.Tag{},
+		&models.Group{},
+		&models.Category{},
+		&models.NoteType{},
+		&models.Preview{},
+		&models.GroupRelation{},
+		&models.GroupRelationType{},
+		&models.ImageHash{},
+		&models.ResourceSimilarity{},
+		&models.LogEntry{},
+		&models.ResourceCategory{},
+		&models.Series{},
+		&models.NoteBlock{},
+		&models.PluginKV{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	altFs := afero.NewMemMapFs()
+
+	// Config.AltFileSystems values are strings that are turned into real FS objects
+	// in NewMahresourcesContext via storage.CreateStorage. For tests we bypass that:
+	// we construct the context normally (no alt-fs in config) and then inject the
+	// in-memory afero directly into the context's altFileSystems map.
+	config := &MahresourcesConfig{
+		DbType: constants.DbTypeSqlite,
+	}
+	fs := afero.NewMemMapFs()
+	sqlDB, _ := db.DB()
+	readOnlyDB := sqlx.NewDb(sqlDB, "sqlite3")
+	ctx := NewMahresourcesContext(fs, db, readOnlyDB, config)
+
+	// Register the in-memory alt-fs (bypasses disk path creation).
+	ctx.RegisterAltFs("archival", altFs)
+	// Also persist the string key in Config so PathName validation works.
+	ctx.Config.AltFileSystems = map[string]string{"archival": "/fake/archival"}
+
+	defaultRC := &models.ResourceCategory{Name: "Default", Description: "Default resource category."}
+	defaultRC.ID = 1
+	db.FirstOrCreate(defaultRC, 1)
+
+	return ctx, altFs
+}
+
+// TestExportImport_PreservesStorageLocation verifies BH-023 layer 1:
+// exporting a resource that has a non-empty StorageLocation writes
+// storage_location to the archive payload, and importing it back restores
+// the StorageLocation field on the re-created resource row.
+func TestExportImport_PreservesStorageLocation(t *testing.T) {
+	// Use t.Name() to get unique DB names across -count=N runs within the same process.
+	// --- Source: isolated DB with alt-fs ---
+	srcCtx, srcAltFs := createContextWithAltFs(t, t.Name()+"-src")
+
+	// Seed the alt-fs with the blob so the exporter can read it.
+	content := []byte("alt-fs content bh023")
+	sum := sha1.Sum(content)
+	hash := fmt.Sprintf("%x", sum)
+	altLoc := "/resources/" + hash
+
+	if err := afero.WriteFile(srcAltFs, altLoc, content, 0644); err != nil {
+		t.Fatalf("write alt-fs blob: %v", err)
+	}
+
+	// Create group + resource with StorageLocation="archival".
+	root := mustCreateGroup(t, srcCtx, "bh023-group", nil)
+
+	storageLoc := "archival"
+	res := &models.Resource{
+		Name:            "bh023-res",
+		ContentType:     "text/plain",
+		FileSize:        int64(len(content)),
+		Hash:            hash,
+		HashType:        "SHA1",
+		Location:        altLoc,
+		StorageLocation: &storageLoc,
+		OwnerId:         &root.ID,
+	}
+	if err := srcCtx.db.Create(res).Error; err != nil {
+		t.Fatalf("create resource: %v", err)
+	}
+
+	// --- Export ---
+	var tarBuf bytes.Buffer
+	err := srcCtx.StreamExport(context.Background(), &ExportRequest{
+		RootGroupIDs: []uint{root.ID},
+		Scope: archive.ExportScope{
+			Subtree:        true,
+			OwnedResources: true,
+		},
+		Fidelity: archive.ExportFidelity{
+			ResourceBlobs: true,
+		},
+	}, &tarBuf, nil)
+	if err != nil {
+		t.Fatalf("StreamExport: %v", err)
+	}
+	tarBytes := tarBuf.Bytes()
+	if len(tarBytes) == 0 {
+		t.Fatal("export produced empty tar")
+	}
+
+	// --- Destination: fresh DB, no overlap with source ---
+	dstCtx := createGUIDIsolatedContext(t, t.Name()+"-dst")
+
+	jobID := "bh023-job"
+	tarPath := filepath.Join("_imports", jobID+".tar")
+	if err := dstCtx.fs.MkdirAll("_imports", 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := afero.WriteFile(dstCtx.fs, tarPath, tarBytes, 0644); err != nil {
+		t.Fatalf("write tar: %v", err)
+	}
+
+	plan, err := dstCtx.ParseImport(context.Background(), jobID, tarPath)
+	if err != nil {
+		t.Fatalf("ParseImport: %v", err)
+	}
+	if plan.Counts.Resources != 1 {
+		t.Fatalf("expected 1 resource in plan, got %d", plan.Counts.Resources)
+	}
+
+	decisions := buildDefaultDecisions(plan)
+	decisions.GUIDCollisionPolicy = "merge"
+
+	result, err := dstCtx.ApplyImport(context.Background(), jobID, decisions, noopSinkAltFS{})
+	if err != nil {
+		t.Fatalf("ApplyImport: %v", err)
+	}
+
+	if result.CreatedResources != 1 {
+		t.Fatalf("expected 1 created resource, got %d (warnings: %v)", result.CreatedResources, result.Warnings)
+	}
+
+	// --- Assert StorageLocation is preserved ---
+	var reimported models.Resource
+	if err := dstCtx.db.First(&reimported, result.CreatedResourceIDs[0]).Error; err != nil {
+		t.Fatalf("load reimported resource: %v", err)
+	}
+
+	if reimported.StorageLocation == nil {
+		t.Fatal("BH-023: reimported resource StorageLocation is nil (expected 'archival')")
+	}
+	if *reimported.StorageLocation != "archival" {
+		t.Errorf("BH-023: reimported StorageLocation = %q, want 'archival'", *reimported.StorageLocation)
+	}
+}

--- a/application_context/resource_upload_context.go
+++ b/application_context/resource_upload_context.go
@@ -702,9 +702,24 @@ func (ctx *MahresourcesContext) AddResource(file interfaces.File, fileName strin
 		return &existingResource, tx.Commit().Error
 	}
 
+	// BH-023: select target filesystem based on PathName (alt-fs key).
+	targetFs := ctx.fs
+	if resourceQuery.PathName != "" {
+		if _, ok := ctx.Config.AltFileSystems[resourceQuery.PathName]; !ok {
+			tx.Rollback()
+			return nil, fmt.Errorf("unknown filesystem: %s", resourceQuery.PathName)
+		}
+		altFs, altErr := ctx.GetFsForStorageLocation(&resourceQuery.PathName)
+		if altErr != nil {
+			tx.Rollback()
+			return nil, altErr
+		}
+		targetFs = altFs
+	}
+
 	folder := "/resources/" + hash[0:2] + "/" + hash[2:4] + "/" + hash[4:6] + "/"
 
-	if err := ctx.fs.MkdirAll(folder, 0777); err != nil {
+	if err := targetFs.MkdirAll(folder, 0777); err != nil {
 		tx.Rollback()
 		return nil, err
 	}
@@ -713,14 +728,14 @@ func (ctx *MahresourcesContext) AddResource(file interfaces.File, fileName strin
 	fileExists := false
 
 	filePath := path.Join(folder, hash+fileMime.Extension())
-	stat, statError := ctx.fs.Stat(filePath)
+	stat, statError := targetFs.Stat(filePath)
 
 	if statError == nil && stat != nil {
-		savedFile, err = ctx.fs.Open(filePath)
+		savedFile, err = targetFs.Open(filePath)
 		log.Printf("Reusing stale file at %s", filePath)
 		fileExists = true
 	} else {
-		savedFile, err = ctx.fs.Create(filePath)
+		savedFile, err = targetFs.Create(filePath)
 	}
 
 	if err != nil {
@@ -786,6 +801,11 @@ func (ctx *MahresourcesContext) AddResource(file interfaces.File, fileName strin
 		OriginalName:       resourceQuery.OriginalName,
 		Width:              uint(width),
 		Height:             uint(height),
+	}
+	// BH-023: set StorageLocation when an alt-fs key was provided.
+	if resourceQuery.PathName != "" {
+		pn := resourceQuery.PathName
+		res.StorageLocation = &pn
 	}
 
 	if err := tx.Save(res).Error; err != nil {

--- a/archive/manifest.go
+++ b/archive/manifest.go
@@ -239,6 +239,7 @@ type ResourcePayload struct {
 	Tags                 []TagRef                 `json:"tags"`
 	Groups               []string                 `json:"groups"`
 	Notes                []string                 `json:"notes"`
+	StorageLocation      string                   `json:"storage_location,omitempty"` // BH-023: alt-fs key; empty = default fs
 	BlobRef              string                   `json:"blob_ref,omitempty"`
 	BlobMissing          bool                     `json:"blob_missing,omitempty"`
 	SeriesRef            string                   `json:"series_ref,omitempty"`

--- a/e2e/tests/c7-bh023-alt-fs-select-visible.spec.ts
+++ b/e2e/tests/c7-bh023-alt-fs-select-visible.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '../fixtures/base.fixture';
+
+// BH-023 — resource-create page must show a Storage <select> when alt-fs is configured.
+//
+// The standard ephemeral test server is started without any alt-fs, so the select
+// is intentionally absent. The test still verifies the template renders without
+// error and the create form is usable. The backend coverage (PathName API and
+// export/import round-trip) lives in the Go unit tests.
+test('BH-023: resource-create page renders without error', async ({ page }) => {
+  await page.goto('/resource/new');
+  // Page must load successfully (no 500, no empty body).
+  await expect(page).toHaveURL(/\/resource\/new/);
+  // The create form must be present.
+  await expect(page.locator('form')).toBeVisible();
+});
+
+test('BH-023: storage select absent when no alt-fs configured', async ({ page }) => {
+  await page.goto('/resource/new');
+  const select = page.locator('select[name="PathName"], [data-testid="resource-storage-select"]');
+  // With no alt-fs configured the select must not be rendered.
+  await expect(select).toHaveCount(0);
+});

--- a/models/query_models/resource_query.go
+++ b/models/query_models/resource_query.go
@@ -21,6 +21,7 @@ type ResourceQueryBase struct {
 
 type ResourceCreator struct {
 	ResourceQueryBase
+	PathName string // BH-023: optional alt-fs key; empty = default filesystem
 }
 
 type ResourceFromLocalCreator struct {
@@ -36,6 +37,7 @@ type ResourceFromRemoteCreator struct {
 	GroupCategoryName string
 	GroupName         string
 	GroupMeta         string
+	PathName          string // BH-023: optional alt-fs key; empty = default filesystem
 }
 
 type ResourceEditor struct {

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -1844,6 +1844,9 @@
   .list-disc {
     list-style-type: disc;
   }
+  .list-none {
+    list-style-type: none;
+  }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }

--- a/server/api_handlers/resource_api_handlers.go
+++ b/server/api_handlers/resource_api_handlers.go
@@ -155,7 +155,8 @@ func GetResourceUploadHandler(ctx interfaces.ResourceCreator) func(writer http.R
 			return
 		}
 
-		creator := query_models.ResourceCreator{ResourceQueryBase: remoteCreator.ResourceQueryBase}
+		// BH-023: thread PathName (alt-fs key) from the decoded form into the creator.
+		creator := query_models.ResourceCreator{ResourceQueryBase: remoteCreator.ResourceQueryBase, PathName: remoteCreator.PathName}
 
 		if request.MultipartForm == nil || request.MultipartForm.File == nil {
 			http_utils.HandleFormError(writer, request, "/resource/new", fmt.Errorf("no multipart form data found"), request.PostForm)

--- a/server/api_tests/resource_create_pathname_test.go
+++ b/server/api_tests/resource_create_pathname_test.go
@@ -1,0 +1,58 @@
+package api_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceCreate_PathNamePersistsStorageLocation verifies that when a
+// multipart resource upload includes a PathName field referencing a configured
+// alt-fs key, the created resource's StorageLocation is set to that key.
+// BH-023 layer 2: ResourceCreator struct must have a PathName field, and
+// AddResource must thread it to resource.StorageLocation.
+func TestResourceCreate_PathNamePersistsStorageLocation(t *testing.T) {
+	tc := SetupTestEnv(t)
+
+	// Configure an alt-fs in the test environment so PathName="archival" is valid.
+	// Both the Config map (for PathName validation) and the internal FS map (for actual IO)
+	// must be set.
+	tc.AppCtx.Config.AltFileSystems = map[string]string{"archival": t.TempDir()}
+	altFs := afero.NewMemMapFs()
+	tc.AppCtx.RegisterAltFs("archival", altFs)
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+
+	part, err := w.CreateFormFile("resource", "bh023.txt")
+	require.NoError(t, err)
+	_, err = io.Copy(part, bytes.NewReader([]byte("hello bh023")))
+	require.NoError(t, err)
+
+	require.NoError(t, w.WriteField("Name", "bh023-altfs"))
+	require.NoError(t, w.WriteField("PathName", "archival"))
+	require.NoError(t, w.Close())
+
+	req, _ := http.NewRequest(http.MethodPost, "/v1/resource", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	rr := httptest.NewRecorder()
+	tc.Router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, "resource create failed: %s", rr.Body.String())
+
+	var resources []map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resources))
+	require.Len(t, resources, 1, "expected exactly one resource in response")
+
+	assert.Equal(t, "archival", resources[0]["StorageLocation"],
+		"StorageLocation must be preserved from multipart PathName (BH-023)")
+}

--- a/server/template_handlers/template_context_providers/resource_template_context.go
+++ b/server/template_handlers/template_context_providers/resource_template_context.go
@@ -119,7 +119,8 @@ func ResourceListContextProvider(context *application_context.MahresourcesContex
 func ResourceCreateContextProvider(context *application_context.MahresourcesContext) func(request *http.Request) pongo2.Context {
 	return func(request *http.Request) pongo2.Context {
 		tplContext := pongo2.Context{
-			"pageTitle": "Create Resource",
+			"pageTitle":      "Create Resource",
+			"altFileSystems": context.Config.AltFileSystems, // BH-023: expose alt-fs keys for Storage select
 		}.Update(StaticTemplateCtx(request))
 
 		var query query_models.EntityIdQuery

--- a/templates/createResource.tpl
+++ b/templates/createResource.tpl
@@ -107,6 +107,28 @@
                         </div>
                     </div>
                 </div>
+
+                {% if altFileSystems %}
+                <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-center sm:border-t sm:border-stone-200 sm:pt-5">
+                    <label for="PathName" class="block text-sm font-medium font-mono text-stone-700 sm:mt-px sm:pt-2">
+                        Storage
+                        <span class="block mt-2 text-sm text-stone-500 font-sans">Choose which filesystem to save this resource to.</span>
+                    </label>
+                    <div class="mt-1 sm:mt-0 sm:col-span-2">
+                        <select
+                            id="PathName"
+                            name="PathName"
+                            data-testid="resource-storage-select"
+                            class="max-w-lg block focus:ring-amber-600 focus:border-amber-600 w-full shadow-sm sm:text-sm border-stone-300 rounded-md"
+                        >
+                            <option value="">Default</option>
+                            {% for key, path in altFileSystems %}
+                            <option value="{{ key }}">{{ key }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                {% endif %}
                 {% endif %}
 
                 <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-center sm:border-t sm:border-stone-200 sm:pt-5">


### PR DESCRIPTION
Closes BH-023.

## Changes

- **Manifest (forward-compat, no schema_version bump):** `archive/manifest.go` adds `ResourcePayload.StorageLocation` as optional `json:"storage_location,omitempty"` field. Unknown keys are silently ignored per CLAUDE.md contract, so older readers remain compatible.
- **Exporter:** `export_context.go` populates `StorageLocation` from `resource.StorageLocation` when non-empty.
- **Importer:** `apply_import.go` restores `StorageLocation` when present in the payload; defaults to nil (default filesystem) when absent.
- **Multipart API:** `ResourceCreator` and `ResourceFromRemoteCreator` gain `PathName` field; API handler threads it through; `AddResource` validates against `Config.AltFileSystems`, uses the alt-fs for file IO, and sets `resource.StorageLocation`.
- **UI:** `createResource.tpl` renders a Storage `<select name="PathName">` populated from `altFileSystems`, visible only when alt-fs is configured and only on the create form (not edit).
- **Template context:** `ResourceCreateContextProvider` exposes `altFileSystems` from `Config.AltFileSystems`.
- **Context helper:** `RegisterAltFs(key, fs)` added to `MahresourcesContext` for test injection (also useful for programmatic setup).

## Tests

- Go API: `TestResourceCreate_PathNamePersistsStorageLocation` — 3× red before fix, 3× green after.
- Go integration: `TestExportImport_PreservesStorageLocation` — red before fix, green after (3× separate runs).
- E2E: `c7-bh023-alt-fs-select-visible.spec.ts` — verifies page renders without error and select is absent when no alt-fs configured.
- Full `go test ./...`: all pass.
- Full E2E (1378 tests): all pass.
- Postgres: pass.

## Contract note

Manifest change is additive and optional. Per CLAUDE.md's stable-contract rule, this is forward-compatible with `schema_version: 1`. No version bump.