### PR TITLE
fix(share): BH-031 — block-state write allowlist

### DIFF
--- a/server/api_tests/share_server_block_state_allowlist_test.go
+++ b/server/api_tests/share_server_block_state_allowlist_test.go
@@ -1,0 +1,139 @@
+package api_tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mahresources/models"
+	"mahresources/server"
+)
+
+// setupShareServer returns the share server's http.Handler for testing.
+func setupShareServer(t *testing.T, tc *TestContext) http.Handler {
+	t.Helper()
+	srv := server.NewShareServer(tc.AppCtx)
+	return srv.Handler()
+}
+
+// shareNote calls POST /v1/note/share and returns the shareToken.
+// Panics if the response is not 200 or no token is returned.
+func shareNote(t *testing.T, tc *TestContext, noteID uint) string {
+	t.Helper()
+	url := fmt.Sprintf("/v1/note/share?noteId=%d", noteID)
+	rr := tc.MakeRequest(http.MethodPost, url, nil)
+	require.Equal(t, http.StatusOK, rr.Code, "shareNote setup failed: HTTP %d body=%s", rr.Code, rr.Body.String())
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+
+	token, _ := body["shareToken"].(string)
+	require.NotEmpty(t, token, "expected shareToken in response, got: %s", rr.Body.String())
+	return token
+}
+
+// TestShareBlockState_RejectsNonTodoBlocks verifies BH-031:
+// a gallery block state write via share token must return 403.
+func TestShareBlockState_RejectsNonTodoBlocks(t *testing.T) {
+	tc := SetupTestEnv(t)
+	shareRouter := setupShareServer(t, tc)
+
+	// Create a note and share it.
+	note := tc.CreateDummyNote("bh031-note")
+	token := shareNote(t, tc, note.ID)
+
+	// Add a gallery block to the note.
+	galleryContent, _ := json.Marshal(map[string]interface{}{"resourceIds": []int{}})
+	gallery := &models.NoteBlock{
+		NoteID:   note.ID,
+		Type:     "gallery",
+		Position: "a",
+		Content:  galleryContent,
+		State:    []byte("{}"),
+	}
+	require.NoError(t, tc.DB.Create(gallery).Error)
+
+	// Attempt to write state to the gallery block via the share server.
+	stateBody, _ := json.Marshal(map[string]interface{}{"layout": "list", "injected": true})
+	url := fmt.Sprintf("/s/%s/block/%d/state", token, gallery.ID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(stateBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	shareRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"BH-031: gallery block state write via share token must be rejected with 403, got %d body=%s",
+		rr.Code, rr.Body.String())
+}
+
+// TestShareBlockState_AllowsTodoBlocks verifies that todos blocks
+// are still writable via the share token after the allowlist is added.
+func TestShareBlockState_AllowsTodoBlocks(t *testing.T) {
+	tc := SetupTestEnv(t)
+	shareRouter := setupShareServer(t, tc)
+
+	note := tc.CreateDummyNote("bh031-note-todo")
+	token := shareNote(t, tc, note.ID)
+
+	todosContent, _ := json.Marshal(map[string]interface{}{
+		"items": []map[string]interface{}{{"id": "t1", "label": "Task", "checked": false}},
+	})
+	todos := &models.NoteBlock{
+		NoteID:   note.ID,
+		Type:     "todos",
+		Position: "a",
+		Content:  todosContent,
+		State:    []byte(`{"items":[{"id":"t1","checked":false}]}`),
+	}
+	require.NoError(t, tc.DB.Create(todos).Error)
+
+	newState := []byte(`{"items":[{"id":"t1","checked":true}]}`)
+	url := fmt.Sprintf("/s/%s/block/%d/state", token, todos.ID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(newState))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	shareRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code,
+		"todos block state write must still succeed after allowlist, got %d body=%s",
+		rr.Code, rr.Body.String())
+}
+
+// TestShareBlockState_RejectsTextBlocks verifies that text blocks are rejected (403).
+func TestShareBlockState_RejectsTextBlocks(t *testing.T) {
+	tc := SetupTestEnv(t)
+	shareRouter := setupShareServer(t, tc)
+
+	note := tc.CreateDummyNote("bh031-note-text")
+	token := shareNote(t, tc, note.ID)
+
+	textContent, _ := json.Marshal(map[string]interface{}{"text": "hello"})
+	textBlock := &models.NoteBlock{
+		NoteID:   note.ID,
+		Type:     "text",
+		Position: "a",
+		Content:  textContent,
+		State:    []byte("{}"),
+	}
+	require.NoError(t, tc.DB.Create(textBlock).Error)
+
+	stateBody := []byte(`{"injected": "evil payload"}`)
+	url := fmt.Sprintf("/s/%s/block/%d/state", token, textBlock.ID)
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(stateBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	shareRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code,
+		"BH-031: text block state write via share token must be rejected with 403, got %d body=%s",
+		rr.Code, rr.Body.String())
+}

--- a/server/share_server.go
+++ b/server/share_server.go
@@ -53,6 +53,13 @@ func NewShareServer(appContext *application_context.MahresourcesContext) *ShareS
 	}
 }
 
+// Handler returns an http.Handler for the share server's routes (useful for testing).
+func (s *ShareServer) Handler() http.Handler {
+	router := mux.NewRouter()
+	s.registerShareRoutes(router)
+	return router
+}
+
 // Start begins the share server on the specified address and port.
 // If port is empty, the server is not started (share feature disabled).
 // The server runs in a goroutine and returns immediately.
@@ -148,16 +155,32 @@ func (s *ShareServer) handleBlockStateUpdate(w http.ResponseWriter, r *http.Requ
 	}
 	blockId := uint(blockIdParsed)
 
-	// Verify block belongs to this note
-	blockBelongsToNote := false
+	// allowedStateBlockTypes is the set of block types that permit state writes via
+	// a share token. Only todos blocks are intended for share-side state writes
+	// (checkbox toggling by anonymous viewers). All other types are read-only.
+	// BH-031: expand this list explicitly if future block types need share-token state writes.
+	var allowedStateBlockTypes = map[string]bool{
+		"todos": true,
+	}
+
+	// Verify block belongs to this note and resolve its type for the allowlist check.
+	var targetBlock *models.NoteBlock
 	for _, block := range note.Blocks {
 		if block.ID == blockId {
-			blockBelongsToNote = true
+			targetBlock = block
 			break
 		}
 	}
-	if !blockBelongsToNote {
+	if targetBlock == nil {
 		http.Error(w, "Block not found", http.StatusNotFound)
+		return
+	}
+
+	// Enforce block-type allowlist: reject non-todo blocks with 403.
+	// The check runs after token→note resolution to avoid leaking block-existence
+	// info on invalid tokens.
+	if !allowedStateBlockTypes[targetBlock.Type] {
+		http.Error(w, "Block type does not allow share-token state writes", http.StatusForbidden)
 		return
 	}
 


### PR DESCRIPTION
Closes BH-031.

## Changes

- `server/share_server.go` — `handleBlockStateUpdate` now resolves the target block's type after note/ownership checks and requires it to be in the `{todos}` allowlist. Non-matching types return 403.
- Added `Handler()` method to `ShareServer` for test isolation (no live port needed).

## Tests

- Go API: ✓ gallery-block state write via share token → 403; text-block state write → 403; todos-block state write → 200. Pass 3× pre-red / post-green.
- Full share test suite: ✓
- Full Go suite: ✓ (pre-existing flaky `TestNewUUIDv7_TimeSorted` fails intermittently on master, unrelated)
- staticcheck: ✓ clean

## Security note

Previously, any holder of a share token could persist arbitrary JSON state to any block type in a shared note. Impact was bounded to the block's `state` column (not content) but represented vandalism and integrity risk. The fix enforces an explicit opt-in allowlist — only `todos` blocks are permitted share-token state writes.

## Bug-hunt-log update

Post-merge: BH-031 → Fixed / closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)