### PR TITLE
fix(bughunt c11): BH-016/017 import UX

### DIFF
--- a/application_context/apply_import.go
+++ b/application_context/apply_import.go
@@ -1002,6 +1002,7 @@ func (s *applyState) applyGroups() error {
 					switch s.decisions.GUIDCollisionPolicy {
 					case "skip":
 						s.skippedM2M[item.ExportID] = true
+						s.result.SkippedByPolicyGroups++
 						if err := walk(item.Children); err != nil {
 							return err
 						}
@@ -1010,10 +1011,15 @@ func (s *applyState) applyGroups() error {
 						if err := s.mergeGroup(&existing, gp); err != nil {
 							return fmt.Errorf("merge group %q: %w", gp.Name, err)
 						}
+						s.result.MergedGroups++
 					case "replace":
 						if err := s.replaceGroup(&existing, gp); err != nil {
 							return fmt.Errorf("replace group %q: %w", gp.Name, err)
 						}
+						// Replace is a mutation-heavy variant of merge; count it
+						// under MergedGroups so the UI surfaces "existing rows
+						// touched" rather than showing "0 created" alone.
+						s.result.MergedGroups++
 					}
 
 					if err := walk(item.Children); err != nil {
@@ -1264,13 +1270,29 @@ func (s *applyState) applyOneResource(tx *gorm.DB, exportID string, rp *archive.
 			switch s.decisions.GUIDCollisionPolicy {
 			case "skip":
 				s.skippedM2M[exportID] = true
+				s.result.SkippedByPolicyResources++
 				return nil
 			case "merge":
-				return s.mergeResource(tx, &existing, rp)
+				if err := s.mergeResource(tx, &existing, rp); err != nil {
+					return err
+				}
+				s.result.MergedResources++
+				return nil
 			case "replace":
-				return s.replaceResource(tx, &existing, rp, batch)
+				if err := s.replaceResource(tx, &existing, rp, batch); err != nil {
+					return err
+				}
+				// Replace is a mutation-heavy variant of merge; count it under
+				// MergedResources so the UI surfaces that existing rows were
+				// touched rather than showing "0 created" alone.
+				s.result.MergedResources++
+				return nil
 			default:
-				return s.mergeResource(tx, &existing, rp)
+				if err := s.mergeResource(tx, &existing, rp); err != nil {
+					return err
+				}
+				s.result.MergedResources++
+				return nil
 			}
 		}
 	}
@@ -1769,15 +1791,21 @@ func (s *applyState) applyOneNote(tx *gorm.DB, exportID string, np *archive.Note
 			switch s.decisions.GUIDCollisionPolicy {
 			case "skip":
 				s.skippedM2M[exportID] = true
+				s.result.SkippedByPolicyNotes++
 				return nil
 			case "merge":
 				if err := s.mergeNote(tx, &existing, np); err != nil {
 					return fmt.Errorf("merge note %q: %w", np.Name, err)
 				}
+				s.result.MergedNotes++
 			case "replace":
 				if err := s.replaceNote(tx, &existing, np); err != nil {
 					return fmt.Errorf("replace note %q: %w", np.Name, err)
 				}
+				// Replace is a mutation-heavy variant of merge; count it under
+				// MergedNotes so the UI surfaces that existing rows were
+				// touched rather than showing "0 created" alone.
+				s.result.MergedNotes++
 			}
 			return nil
 		}

--- a/application_context/import_counters_test.go
+++ b/application_context/import_counters_test.go
@@ -1,0 +1,47 @@
+package application_context
+
+import (
+	"testing"
+)
+
+// TestImportApplyResult_NewCounters documents the expected fields added by BH-016.
+// The counters are only meaningful once apply_import wires them — the compile
+// check alone is enough to confirm the struct is extended.
+func TestImportApplyResult_NewCounters(t *testing.T) {
+	r := ImportApplyResult{}
+
+	// BH-016: new counters — merged (GUID-collision policy=merge)
+	_ = r.MergedGroups
+	_ = r.MergedResources
+	_ = r.MergedNotes
+
+	// BH-016: new counters — linked by GUID (re-link path: existing GUID row
+	// referenced by an incoming payload that targets the same entity)
+	_ = r.LinkedByGUIDGroups
+	_ = r.LinkedByGUIDResources
+	_ = r.LinkedByGUIDNotes
+
+	// BH-016: new counters — skipped by GUID-collision policy=skip
+	_ = r.SkippedByPolicyGroups
+	_ = r.SkippedByPolicyResources
+	_ = r.SkippedByPolicyNotes
+}
+
+// TestHasMutations_NewCounters ensures the new counters participate in the
+// "did this import actually change anything" check, so retry-safety logic
+// treats a merge-only import as a mutation too.
+func TestHasMutations_NewCounters(t *testing.T) {
+	mergeOnly := ImportApplyResult{MergedGroups: 1}
+	if !mergeOnly.HasMutations() {
+		t.Fatal("expected HasMutations=true when MergedGroups>0")
+	}
+	linkOnly := ImportApplyResult{LinkedByGUIDResources: 1}
+	if !linkOnly.HasMutations() {
+		t.Fatal("expected HasMutations=true when LinkedByGUIDResources>0")
+	}
+	// SkippedByPolicy is NOT a mutation — the row existed before.
+	skipOnly := ImportApplyResult{SkippedByPolicyNotes: 2}
+	if skipOnly.HasMutations() {
+		t.Fatal("expected HasMutations=false when only SkippedByPolicy>0")
+	}
+}

--- a/application_context/import_plan.go
+++ b/application_context/import_plan.go
@@ -168,7 +168,28 @@ type ImportApplyResult struct {
 	CreatedVersions           int      `json:"created_versions"`
 	CreatedShellGroups        int      `json:"created_shell_groups"`
 	MappedShellGroups         int      `json:"mapped_shell_groups"`
-	Warnings                  []string `json:"warnings"`
+
+	// BH-016: GUID-collision policy=merge counters — merged existing rows with incoming payload
+	MergedGroups    int `json:"merged_groups"`
+	MergedResources int `json:"merged_resources"`
+	MergedNotes     int `json:"merged_notes"`
+
+	// BH-016: re-link counters — incoming GUID matched an existing row; no new row
+	// created, but the plan's foreign-key targets were wired to the existing row.
+	// Reserved for future wiring — currently 0. Today, GUID collisions always take
+	// one of merge/replace/skip; there is no standalone "link-only" branch in
+	// apply_import.go. Emitted for forward-compatibility with a future policy.
+	LinkedByGUIDGroups    int `json:"linked_by_guid_groups"`
+	LinkedByGUIDResources int `json:"linked_by_guid_resources"`
+	LinkedByGUIDNotes     int `json:"linked_by_guid_notes"`
+
+	// BH-016: GUID-collision policy=skip counters — incoming payload skipped,
+	// existing row untouched (no data mutation).
+	SkippedByPolicyGroups    int `json:"skipped_by_policy_groups"`
+	SkippedByPolicyResources int `json:"skipped_by_policy_resources"`
+	SkippedByPolicyNotes     int `json:"skipped_by_policy_notes"`
+
+	Warnings []string `json:"warnings"`
 
 	// Created IDs per phase — enables manual cleanup after partial failure.
 	CreatedGroupIDs    []uint `json:"created_group_ids,omitempty"`
@@ -201,6 +222,12 @@ func (r *ImportApplyResult) HasMutations() bool {
 		r.CreatedGroups > 0 || r.CreatedResources > 0 ||
 		r.CreatedNotes > 0 || r.CreatedShellGroups > 0 ||
 		r.CreatedVersions > 0 || r.CreatedPreviews > 0 {
+		return true
+	}
+	// BH-016: merges and re-links are mutations (existing rows updated / wired).
+	// SkippedByPolicy is NOT a mutation — the row existed before the apply.
+	if r.MergedGroups > 0 || r.MergedResources > 0 || r.MergedNotes > 0 ||
+		r.LinkedByGUIDGroups > 0 || r.LinkedByGUIDResources > 0 || r.LinkedByGUIDNotes > 0 {
 		return true
 	}
 	return len(r.CreatedGroupIDs) > 0 || len(r.CreatedResourceIDs) > 0 || len(r.CreatedNoteIDs) > 0

--- a/archive/reader.go
+++ b/archive/reader.go
@@ -64,11 +64,28 @@ func (r *Reader) ReadManifest() (*Manifest, error) {
 	if hdr.Name != "manifest.json" {
 		return nil, fmt.Errorf("archive: first entry %q != manifest.json", hdr.Name)
 	}
+	// BH-017: read the manifest body once so we can parse it twice — once as
+	// a map to presence-check required fields, once into the typed Manifest.
+	// Previously, Go's int zero-value meant an absent `schema_version` field
+	// decoded to 0 and got reported as "unsupported schema_version 0", which
+	// misled users who had simply omitted the field.
+	raw, err := io.ReadAll(r.tr)
+	if err != nil {
+		return nil, fmt.Errorf("archive: read manifest body: %w", err)
+	}
+
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawFields); err != nil {
+		return nil, fmt.Errorf("archive: parse manifest: %w", err)
+	}
+	if _, hasVersion := rawFields["schema_version"]; !hasVersion {
+		return nil, &ErrMissingSchemaVersion{}
+	}
+
 	var m Manifest
-	dec := json.NewDecoder(r.tr)
 	// Do NOT call DisallowUnknownFields — §6.4 requires forward compatibility
 	// with unknown top-level keys.
-	if err := dec.Decode(&m); err != nil {
+	if err := json.Unmarshal(raw, &m); err != nil {
 		return nil, fmt.Errorf("archive: parse manifest: %w", err)
 	}
 	if !isSupportedVersion(m.SchemaVersion) {

--- a/archive/reader_missing_schema_version_test.go
+++ b/archive/reader_missing_schema_version_test.go
@@ -1,0 +1,75 @@
+package archive_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"mahresources/archive"
+)
+
+// buildManifestTar packs a single manifest.json entry whose content is the
+// supplied JSON bytes. Returns the tar stream so tests can feed it to
+// archive.NewReader.
+func buildManifestTar(t *testing.T, manifestJSON []byte) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: "manifest.json", Mode: 0o600, Size: int64(len(manifestJSON))}); err != nil {
+		t.Fatalf("tw.WriteHeader: %v", err)
+	}
+	if _, err := tw.Write(manifestJSON); err != nil {
+		t.Fatalf("tw.Write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close: %v", err)
+	}
+	return &buf
+}
+
+// BH-017: omitting schema_version entirely should produce a "missing required
+// field" error, NOT the misleading "unsupported schema_version 0".
+func TestReadManifest_MissingSchemaVersion(t *testing.T) {
+	json := []byte(`{"created_at":"2026-04-22T00:00:00Z","created_by":"test"}`)
+	buf := buildManifestTar(t, json)
+
+	r, err := archive.NewReader(buf)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	_, err = r.ReadManifest()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var missing *archive.ErrMissingSchemaVersion
+	if !errors.As(err, &missing) {
+		t.Fatalf("expected ErrMissingSchemaVersion, got %T: %v", err, err)
+	}
+	msg := err.Error()
+	for _, substr := range []string{"missing", "schema_version"} {
+		if !strings.Contains(msg, substr) {
+			t.Errorf("error message %q missing substring %q", msg, substr)
+		}
+	}
+}
+
+// TestReadManifest_UnsupportedVersion keeps coverage on the existing branch.
+func TestReadManifest_UnsupportedVersion(t *testing.T) {
+	json := []byte(`{"schema_version":9999,"created_at":"2026-04-22T00:00:00Z"}`)
+	buf := buildManifestTar(t, json)
+
+	r, err := archive.NewReader(buf)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	_, err = r.ReadManifest()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var unsup *archive.ErrUnsupportedSchemaVersion
+	if !errors.As(err, &unsup) {
+		t.Fatalf("expected ErrUnsupportedSchemaVersion, got %T: %v", err, err)
+	}
+}

--- a/archive/version.go
+++ b/archive/version.go
@@ -20,3 +20,14 @@ type ErrUnsupportedSchemaVersion struct {
 func (e *ErrUnsupportedSchemaVersion) Error() string {
 	return fmt.Sprintf("archive: unsupported schema_version %d (supported: %v)", e.Got, e.Supported)
 }
+
+// ErrMissingSchemaVersion is returned by Reader.ReadManifest when the
+// manifest.json lacks the `schema_version` field entirely. Distinguished
+// from ErrUnsupportedSchemaVersion (present but invalid value) because
+// "schema_version:0" was previously reported as "unsupported version 0",
+// which misled users who had simply omitted the field. BH-017.
+type ErrMissingSchemaVersion struct{}
+
+func (e *ErrMissingSchemaVersion) Error() string {
+	return "archive: manifest is missing required field `schema_version`"
+}

--- a/tasks/bug-hunt-log.md
+++ b/tasks/bug-hunt-log.md
@@ -360,7 +360,8 @@ _(populated by iterations — newest first)_
 - **Evidence:** `tasks/bug-hunt-evidence/iter-2026-04-22-1/resource-dup-b-similar-section.png`; code citations above.
 
 ### BH-017 · Missing `schema_version` in a group-import manifest produces the misleading error "unsupported schema_version 0"
-- **Status:** verified (iter 5)
+- **Status:** **FIXED** (2026-04-22, c11-import-ux, PR #XX merged <sha> — see Fixed / closed table below)
+- **Original status (pre-fix):** verified (iter 5)
 - **Severity:** cosmetic (correctness is fine — the import IS rejected; but the message is confusing)
 - **Iter:** 5 · **Workflow:** group import manifest contract probe
 - **Repro:** remove `schema_version` entirely from a valid manifest.json inside the export tar, re-tar, import. Error surfaced: `archive: unsupported schema_version 0 (supported: [1])`.
@@ -368,7 +369,8 @@ _(populated by iterations — newest first)_
 - **Fix:** at manifest parse time, distinguish "field absent" (use a `*int` or a presence flag) from "field == 0"; emit "manifest is missing required field `schema_version`" for the former.
 
 ### BH-016 · Import result UI hides GUID-reused AND GUID-merged entities — shows "0 created" when the import actually re-linked or merged existing ones
-- **Status:** verified (iter 5), scope confirmed broader in iter 6 (merge path also silent)
+- **Status:** **FIXED** (2026-04-22, c11-import-ux, PR #XX merged <sha> — see Fixed / closed table below)
+- **Original status (pre-fix):** verified (iter 5), scope confirmed broader in iter 6 (merge path also silent)
 - **Severity:** minor (misleading feedback; no data loss)
 - **Iter:** 5 (re-link path) + 6 (merge path)
 - **Observation (iter 5, re-link path):** exported a group, deleted it (but not its notes/resources — BH-014's orphan semantics), re-imported the tar. Result: `Groups created: 3, Resources created: 0, Notes created: 0`. The 2 notes + 2 resources were re-linked by GUID but that's invisible.
@@ -615,6 +617,8 @@ _(populated by iterations — newest first)_
 | BH-007 | **fixed** (2026-04-22, c13-cosmetic-cleanup, PR #32 merged fec44787) | `templates/partials/versionPanel.tpl` action bar now uses `flex flex-wrap gap-y-2` so the upload form drops to a second row on narrow widths; the Compare toggle + Compare-Selected share an inner flex row; both action buttons get `whitespace-nowrap` so labels never split mid-label. E2E: `e2e/tests/c13-bh007-version-panel-layout.spec.ts` asserts button height stays within 1.8x its line-height with Compare Selected visible at 1024px. |
 | BH-015 | **fixed** (2026-04-22, c10-jobs-ui-polish, PR #35 merged dd2c68b2) | UI cap: `Math.min(100, ...)` on both label sites (`templates/adminExport.tpl:122`, `src/components/downloadCockpit.js` `formatProgress`). Backend accuracy: new `estimateJSONOverhead(plan)` adds `2 KB manifest + 1 KB × entity count` to `plan.totalBytes` at the end of `buildExportPlan` in `application_context/export_context.go`. Unit: `application_context/export_overhead_test.go`. E2E: `e2e/tests/c10-bh015-export-progress-cap.spec.ts`. |
 | BH-036 | **fixed** (2026-04-22, c10-jobs-ui-polish, PR #35 merged dd2c68b2) | `/admin/export` gains a helper line citing `config.ExportRetention` (`templates/adminExport.tpl` `data-testid="export-retention-helper"`). `downloadCockpit` shows an "Expires in X" line per completed group-export row, computed from `job.completedAt + exportRetentionMs`. Values threaded into every template via `wrapContextWithPlugins` in `server/routes.go`; ms variant shipped to the client via a `<meta name="x-export-retention-ms">` tag on `base.tpl` and read by `downloadCockpit.js` on init. E2E: `e2e/tests/c10-bh036-export-retention-disclosure.spec.ts`. |
+| BH-016 | **fixed** (2026-04-22, c11-import-ux, PR #XX merged <sha>) | `ImportApplyResult` in `application_context/import_plan.go` gains 9 new counters: `MergedGroups/Resources/Notes`, `LinkedByGUIDGroups/Resources/Notes` (reserved — forward-compat), `SkippedByPolicyGroups/Resources/Notes`. Wired into `apply_import.go` at the GUID-collision switches for groups, resources, and notes; `replace` branches also bump `Merged*` (replace is a mutation-heavy variant of merge). `HasMutations()` extended accordingly. `templates/adminImport.tpl` surfaces created + merged + skipped-by-policy per entity type. Unit: `application_context/import_counters_test.go`. |
+| BH-017 | **fixed** (2026-04-22, c11-import-ux, PR #XX merged <sha>) | `archive/reader.go::ReadManifest` now reads the manifest body once, unmarshals into a `map[string]json.RawMessage` to presence-check `schema_version`, then unmarshals into the typed `Manifest`. Absent field → new `ErrMissingSchemaVersion` ("manifest is missing required field `schema_version`"). Present-but-invalid → existing `ErrUnsupportedSchemaVersion`. Unit: `archive/reader_missing_schema_version_test.go`. |
 
 ---
 

--- a/templates/adminImport.tpl
+++ b/templates/adminImport.tpl
@@ -380,13 +380,28 @@
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
               <span class="font-medium">Import completed</span>
             </div>
-            <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+            <dl class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm" data-testid="import-apply-result">
               <dt class="text-stone-500">Groups created</dt>
               <dd x-text="applyResult.created_groups"></dd>
+              <dt class="text-stone-500">Groups merged</dt>
+              <dd x-text="applyResult.merged_groups || 0"></dd>
+              <dt class="text-stone-500">Groups skipped (policy)</dt>
+              <dd x-text="applyResult.skipped_by_policy_groups || 0"></dd>
+
               <dt class="text-stone-500">Resources created</dt>
               <dd x-text="applyResult.created_resources"></dd>
+              <dt class="text-stone-500">Resources merged</dt>
+              <dd x-text="applyResult.merged_resources || 0"></dd>
+              <dt class="text-stone-500">Resources skipped (policy)</dt>
+              <dd x-text="applyResult.skipped_by_policy_resources || 0"></dd>
+
               <dt class="text-stone-500">Notes created</dt>
               <dd x-text="applyResult.created_notes"></dd>
+              <dt class="text-stone-500">Notes merged</dt>
+              <dd x-text="applyResult.merged_notes || 0"></dd>
+              <dt class="text-stone-500">Notes skipped (policy)</dt>
+              <dd x-text="applyResult.skipped_by_policy_notes || 0"></dd>
+
               <dt class="text-stone-500">Skipped (hash match)</dt>
               <dd x-text="applyResult.skipped_by_hash"></dd>
               <dt class="text-stone-500">Skipped (missing bytes)</dt>


### PR DESCRIPTION
## Summary
- **BH-016** — `ImportApplyResult` gains 9 new counters (merged × 3, linked-by-GUID × 3 reserved, skipped-by-policy × 3). `apply_import.go` wires them at the GUID-collision switch for groups/resources/notes. `replace` branches count as merges (replace is a mutation-heavy variant). `templates/adminImport.tpl` surfaces created + merged + skipped-by-policy per entity type.
- **BH-017** — `archive/reader.go::ReadManifest` now presence-checks `schema_version` via a `map[string]json.RawMessage` pre-pass. Absent → new `ErrMissingSchemaVersion` ("missing required field `schema_version`"). Present-but-invalid → existing `ErrUnsupportedSchemaVersion`.

Spec: `docs/superpowers/specs/2026-04-22-bughunt-batch-c9-c18-design.md` — cluster 11.
Plan: `docs/superpowers/plans/2026-04-22-bug-backlog-c11-import-ux.md`.

## Decisions
- **LinkedByGUID counters are reserved at 0.** There is no standalone "link existing by GUID" branch in `apply_import.go` — collisions always go merge/replace/skip. Emitting the fields for forward-compat with a potential future policy; documented in code.
- **`replace` policy counts as `Merged*`.** Keeps the UI story simple: "existing rows touched" = merged + replaced, "new rows" = created. Operators who want the distinction should grep the server logs.

## Test plan
- [x] Go unit tests pass (SQLite, `json1 fts5`)
- [x] `TestImportApplyResult_NewCounters`, `TestHasMutations_NewCounters`, `TestReadManifest_MissingSchemaVersion`, `TestReadManifest_UnsupportedVersion` all green
- [x] Existing archive roundtrip tests still pass (body-read-then-reparse path)
- [x] `tasks/bug-hunt-log.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)