### PR TITLE
Auto-select versions when entering compare mode with exactly 2 versions

### DIFF
--- a/templates/partials/versionPanel.tpl
+++ b/templates/partials/versionPanel.tpl
@@ -1,5 +1,5 @@
 {% if versions %}
-<details class="detail-collapsible mb-6" x-data="{ compareMode: false, selected: [] }" {% if versions|length > 1 %}open{% endif %}>
+<details class="detail-collapsible mb-6" x-data="{ compareMode: false, selected: [], allVersionNumbers: [{% for v in versions %}{{ v.VersionNumber }}{% if not forloop.last %},{% endif %}{% endfor %}] }" {% if versions|length > 1 %}open{% endif %}>
     <summary>Versions ({{ versions|length }})</summary>
     <div class="detail-panel-body">
         {% for version in versions %}
@@ -54,7 +54,7 @@
         <div class="p-4 bg-stone-50">
             <div class="flex flex-wrap items-center gap-y-2 gap-x-4 justify-between">
                 <div class="flex items-center gap-2">
-                    <button @click="compareMode = !compareMode; selected = []"
+                    <button @click="compareMode = !compareMode; selected = compareMode && allVersionNumbers.length === 2 ? [...allVersionNumbers] : []"
                             class="px-3 py-1 text-sm border rounded hover:bg-stone-100"
                             :class="{ 'bg-amber-100 border-amber-300': compareMode }">
                         <span x-text="compareMode ? 'Cancel Compare' : 'Compare'"></span>


### PR DESCRIPTION
## Summary
Enhanced the version comparison feature to automatically pre-select all available versions when entering compare mode, but only when exactly 2 versions exist. This improves the user experience by eliminating the need for manual selection in the common two-version comparison scenario.

## Key Changes
- Added `allVersionNumbers` array to the Alpine.js component data, populated with all available version numbers from the versions list
- Modified the compare mode toggle logic to automatically select all versions when:
  - Compare mode is being enabled (`compareMode` becomes true)
  - AND exactly 2 versions are available (`allVersionNumbers.length === 2`)
- When compare mode is disabled or when there are not exactly 2 versions, the selection is cleared as before

## Implementation Details
- The version numbers are extracted server-side in the template using a loop and stored in the Alpine.js data object
- The auto-selection uses the spread operator to populate the `selected` array with all version numbers
- This maintains backward compatibility: users with more or fewer than 2 versions will still need to manually select versions to compare

https://claude.ai/code/session_01KD39cT9kLDvMpX7jKqjZqB