### PR TITLE
Reduce z-index of bulk editor toolbars from 50 to 30

### DIFF
--- a/templates/partials/bulkEditorGroup.tpl
+++ b/templates/partials/bulkEditorGroup.tpl
@@ -1,7 +1,7 @@
 <div class="pb-3" x-data x-show="[...$store.bulkSelection.selectedIds].length === 0" x-collapse>
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
 </div>
-<div x-cloak class="sticky top-0 z-50 flex pl-4 pb-2 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
+<div x-cloak class="sticky top-0 z-30 flex pl-4 pb-2 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
     {% include "/partials/form/formParts/connected/deselectButton.tpl" %}
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
     <form class="px-4" method="post" :action="'/v1/groups/addTags?redirect=' + encodeURIComponent(window.location.pathname + window.location.search)">

--- a/templates/partials/bulkEditorNote.tpl
+++ b/templates/partials/bulkEditorNote.tpl
@@ -1,7 +1,7 @@
 <div class="pb-3" x-data x-show="[...$store.bulkSelection.selectedIds].length === 0" x-collapse>
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
 </div>
-<div x-cloak class="sticky top-0 z-50 flex pl-4 pb-2 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
+<div x-cloak class="sticky top-0 z-30 flex pl-4 pb-2 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
     {% include "/partials/form/formParts/connected/deselectButton.tpl" %}
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
     <form class="px-4" method="post" :action="'/v1/notes/addTags?redirect=' + encodeURIComponent(window.location.pathname + window.location.search)">

--- a/templates/partials/bulkEditorResource.tpl
+++ b/templates/partials/bulkEditorResource.tpl
@@ -1,7 +1,7 @@
 <div class="pb-3" x-data x-show="[...$store.bulkSelection.selectedIds].length === 0" x-collapse>
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
 </div>
-<div class="sticky top-0 z-50 flex pl-4 pb-2 gap-4 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
+<div class="sticky top-0 z-30 flex pl-4 pb-2 gap-4 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
     {% include "/partials/form/formParts/connected/deselectButton.tpl" %}
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
     <form class="px-4" method="post" :action="'/v1/resources/addTags?redirect=' + encodeURIComponent(window.location.pathname + window.location.search)">

--- a/templates/partials/bulkEditorTag.tpl
+++ b/templates/partials/bulkEditorTag.tpl
@@ -1,7 +1,7 @@
 <div class="pb-3" x-data x-show="[...$store.bulkSelection.selectedIds].length === 0" x-collapse>
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
 </div>
-<div x-cloak class="sticky top-0 z-50 flex pl-4 pb-2 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
+<div x-cloak class="sticky top-0 z-30 flex pl-4 pb-2 lg:gap-4 gap-1 flex-wrap bulk-editors items-center" x-show="[...$store.bulkSelection.selectedIds].length > 0" x-collapse x-data="bulkSelectionForms">
     {% include "/partials/form/formParts/connected/deselectButton.tpl" %}
     {% include "/partials/form/formParts/connected/selectAllButton.tpl" %}
     <form


### PR DESCRIPTION
## Summary
Adjusted the z-index stacking context for bulk editor toolbars across all entity types to prevent them from overlaying other high-z-index UI elements.

## Changes
- Updated z-index from `z-50` to `z-30` in bulk editor toolbar components:
  - `bulkEditorGroup.tpl`
  - `bulkEditorNote.tpl`
  - `bulkEditorResource.tpl`
  - `bulkEditorTag.tpl`

## Details
The bulk editor toolbars (sticky positioned elements at the top of the page) were using `z-50`, which could cause them to appear above other important UI elements. Reducing this to `z-30` maintains their visibility above most page content while allowing other critical UI components with higher z-index values to remain on top when needed.

https://claude.ai/code/session_01FY2T45MNnaXrftwVVunjqv