### PR TITLE
⚡ Optimize SQLite schema retrieval (eliminate N+1 query)

### DIFF
--- a/application_context/query_context.go
+++ b/application_context/query_context.go
@@ -146,53 +146,27 @@ func (ctx *MahresourcesContext) GetDatabaseSchema() (map[string][]string, error)
 	}
 
 	// SQLite path
-	tableRows, err := sqlDB.Query(
-		`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
+	rows, err := sqlDB.Query(
+		`SELECT m.name as table_name, p.name as column_name
+		 FROM sqlite_master m
+		 JOIN pragma_table_info(m.name) p
+		 WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%'
+		 ORDER BY m.name, p.cid`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("querying sqlite tables: %w", err)
+		return nil, fmt.Errorf("querying sqlite schema: %w", err)
 	}
-	defer tableRows.Close()
+	defer rows.Close()
 
-	var tables []string
-	for tableRows.Next() {
-		var name string
-		if err := tableRows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("scanning sqlite table name: %w", err)
+	for rows.Next() {
+		var table, column string
+		if err := rows.Scan(&table, &column); err != nil {
+			return nil, fmt.Errorf("scanning sqlite schema row: %w", err)
 		}
-		tables = append(tables, name)
-	}
-	if err := tableRows.Err(); err != nil {
-		return nil, err
+		schema[table] = append(schema[table], column)
 	}
 
-	for _, table := range tables {
-		colRows, err := sqlDB.Query(fmt.Sprintf(`PRAGMA table_info("%s")`, table))
-		if err != nil {
-			return nil, fmt.Errorf("querying columns for table %s: %w", table, err)
-		}
-
-		var columns []string
-		for colRows.Next() {
-			var cid int
-			var name, colType string
-			var notNull, pk int
-			var dfltValue *string
-			if err := colRows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
-				colRows.Close()
-				return nil, fmt.Errorf("scanning column info for table %s: %w", table, err)
-			}
-			columns = append(columns, name)
-		}
-		colRows.Close()
-		if err := colRows.Err(); err != nil {
-			return nil, err
-		}
-
-		schema[table] = columns
-	}
-
-	return schema, nil
+	return schema, rows.Err()
 }
 
 func (ctx *MahresourcesContext) DeleteQuery(queryId uint) error {

--- a/application_context/query_context_schema_test.go
+++ b/application_context/query_context_schema_test.go
@@ -1,0 +1,58 @@
+package application_context
+
+import (
+	"mahresources/constants"
+	"testing"
+)
+
+func TestGetDatabaseSchema_SQLite_Correctness(t *testing.T) {
+	cfg := &MahresourcesInputConfig{
+		MemoryDB: true,
+		MemoryFS: true,
+	}
+	ctx, gormDB, _ := CreateContextWithConfig(cfg)
+	ctx.Config.DbType = constants.DbTypeSqlite
+
+	// Create tables with specific column orders
+	err := gormDB.Exec("CREATE TABLE test_table_1 (id INTEGER, name TEXT)").Error
+	if err != nil {
+		t.Fatalf("failed to create table 1: %v", err)
+	}
+	err = gormDB.Exec("CREATE TABLE test_table_2 (id INTEGER, description TEXT, created_at DATETIME)").Error
+	if err != nil {
+		t.Fatalf("failed to create table 2: %v", err)
+	}
+
+	schema, err := ctx.GetDatabaseSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify table existence
+	if _, ok := schema["test_table_1"]; !ok {
+		t.Error("test_table_1 not found in schema")
+	}
+	if _, ok := schema["test_table_2"]; !ok {
+		t.Error("test_table_2 not found in schema")
+	}
+
+	// Verify column count and order for table 1
+	cols1 := schema["test_table_1"]
+	if len(cols1) != 2 {
+		t.Errorf("expected 2 columns for test_table_1, got %d: %v", len(cols1), cols1)
+	} else {
+		if cols1[0] != "id" || cols1[1] != "name" {
+			t.Errorf("incorrect column order for test_table_1, got %v, expected [id name]", cols1)
+		}
+	}
+
+	// Verify column count and order for table 2
+	cols2 := schema["test_table_2"]
+	if len(cols2) != 3 {
+		t.Errorf("expected 3 columns for test_table_2, got %d: %v", len(cols2), cols2)
+	} else {
+		if cols2[0] != "id" || cols2[1] != "description" || cols2[2] != "created_at" {
+			t.Errorf("incorrect column order for test_table_2, got %v, expected [id description created_at]", cols2)
+		}
+	}
+}


### PR DESCRIPTION
### 💡 What: The optimization implemented
Optimized the `GetDatabaseSchema` function in `application_context/query_context.go` for SQLite by replacing an N+1 query pattern with a single batch query.

### 🎯 Why: The performance problem it solves
Previously, the code would first fetch all table names and then iterate through them, executing a `PRAGMA table_info` query for each individual table. In a database with many tables, this resulted in numerous small, synchronous database round-trips, causing unnecessary overhead.

### 📊 Measured Improvement
While environment-specific performance measurements were impractical due to extreme slowness and timeouts in the provided sandbox, this change is a textbook optimization that reduces database round-trips from **O(N)** (where N is the number of tables) to **O(1)**. This provides a guaranteed performance boost, especially as the database schema grows.

The new implementation uses a single SQL query:
```sql
SELECT m.name as table_name, p.name as column_name
FROM sqlite_master m
JOIN pragma_table_info(m.name) p
WHERE m.type = 'table' AND m.name NOT LIKE 'sqlite_%'
ORDER BY m.name, p.cid
```
This query is supported in modern SQLite versions and efficiently retrieves all table/column pairs in one go. Correctness was verified by manually testing the SQL logic in a separate SQLite environment.

---
*PR created automatically by Jules for task [11036049836011496349](https://jules.google.com/task/11036049836011496349) started by @egeozcan*