### PR TITLE
Abort in-flight preview requests when closing timeline preview panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /public/*.html
 /*.output.png
 /=file
+/server.log
 .aider*
 
 # E2E test artifacts

--- a/server.log
+++ b/server.log
@@ -1,1 +1,0 @@
-go: go.mod requires go >= 1.25.6 (runnigo: download go1.25.6: golang.org/toolchain@v0.0.1-go1.25.6.linux-amd64: Get "https://proxy.golang.org/golang.org/toolchain/@v/v0.0.1-go1.25.6.linux-amd64.zip": dial tcp 74.125.132.141:443: i/o timeout

--- a/server.log
+++ b/server.log
@@ -1,0 +1,1 @@
+go: go.mod requires go >= 1.25.6 (runnigo: download go1.25.6: golang.org/toolchain@v0.0.1-go1.25.6.linux-amd64: Get "https://proxy.golang.org/golang.org/toolchain/@v/v0.0.1-go1.25.6.linux-amd64.zip": dial tcp 74.125.132.141:443: i/o timeout

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -283,11 +283,6 @@ export default function timeline({ apiUrl, entityType, defaultView }) {
         async selectBar(index, barType) {
             // Toggle off if clicking same bar
             if (this.selectedBar === index && this.selectedBarType === barType) {
-                // P3 fix: abort in-flight preview before closing
-                if (this._previewAborter) {
-                    this._previewAborter();
-                    this._previewAborter = null;
-                }
                 this.closePreview();
                 this.renderChart();
                 return;
@@ -375,6 +370,10 @@ export default function timeline({ apiUrl, entityType, defaultView }) {
         },
 
         closePreview() {
+            if (this._previewAborter) {
+                this._previewAborter();
+                this._previewAborter = null;
+            }
             this.selectedBar = null;
             this.selectedBarType = null;
             this.previewHtml = '';


### PR DESCRIPTION
This change ensures that any pending network requests for the preview are aborted when the preview panel is closed. The abortion logic has been centralized in the closePreview method to ensure it's triggered by all actions that close the preview. Redundant abortion logic in selectBar has been removed.