### PR TITLE
Rewrite README with clearer structure and comprehensive feature overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mahresources
+# Mahresources
 
-A personal information management system built in Go. Organize files, notes, and collections with rich metadata, full-text search, and a flexible tagging system — designed to scale to millions of resources.
+Mahresources is a self-hosted system for storing files, writing notes, and linking them together. It runs as a single Go binary with SQLite or PostgreSQL, and serves a web UI for browsing, searching, and editing everything. It is built to stay usable at libraries of millions of resources.
 
 **[Read the full documentation](https://egeozcan.github.io/mahresources/)**
 
@@ -33,42 +33,83 @@ A personal information management system built in Go. Organize files, notes, and
       <em>Global Search (Cmd/Ctrl+K)</em>
     </td>
     <td align="center">
-      <img src="docs-site/static/img/bulk-selection.png" width="400" alt="Bulk operations toolbar"><br>
-      <em>Bulk Operations</em>
+      <img src="docs-site/static/img/timeline-view.png" width="400" alt="Timeline view of recent activity"><br>
+      <em>Timeline View</em>
     </td>
   </tr>
 </table>
 
-## Features
+## What It Does
 
-- **Resources** — Store and manage files with automatic thumbnail generation, perceptual hashing for duplicate/similarity detection, and version tracking
-- **Notes** — Rich text content with structured block types and sharing capabilities
-- **Groups** — Hierarchical collections with typed relationships between them
-- **Tags & Categories** — Flexible labeling system across all entity types
-- **Full-Text Search** — Fast search across all content with saved queries
-- **JSON Metadata** — Attach queryable JSON metadata to any entity, with schema validation
-- **Bulk Operations** — Tag, merge, delete, or update many items at once
-- **Plugin System** — Extend functionality with Lua plugins, custom actions, and hooks
-- **Dual API** — Every route serves both HTML and JSON (append `.json` or set `Accept: application/json`)
-- **Group Export / Import** — export a group subtree (with resources, notes, tags, categories) to a self-contained tar archive via the `/admin/export` page, HTTP API, or `mr group export` CLI
-- **SQLite & Postgres** — Choose the database that fits your needs
+Files (called **Resources**), **Notes**, and **Groups** live in a database with tracked relationships and full-text search. Groups nest inside each other and hold any mix of Resources and Notes. **Tags** and **Categories** classify items across the hierarchy.
+
+### Content
+
+- **Resources** — any file type, with automatic thumbnails (images natively, video through FFmpeg, Office documents through LibreOffice), perceptual hashing for similarity detection, and full version history
+- **Notes** — text content assembled from typed **note blocks**: text, heading, divider, gallery, references, todos, table, and calendar. Plugins can register more block types
+- **Groups** — a nested hierarchy that owns Resources, Notes, and other Groups, plus typed **relations** between Groups ("works at", "parent of")
+- **Series** — Resources that share metadata, such as the pages of one scanned document
+- **Tags, Categories, Resource Categories, and Note Types** — flat labels, and types that give each entity its own presentation
+
+### Finding Things
+
+- **Full-text search** across all content, via FTS5 on SQLite or tsvector on PostgreSQL, reachable from anywhere with Cmd/Ctrl+K
+- **MRQL** — a query language for Resources, Notes, and Groups, with its own page at `/mrql`, a filter bar on every list page, saved queries, and an `[mrql]` shortcode that embeds results in templates
+- **Saved queries** — stored raw SQL with custom result templates; point `DB_READONLY_DSN` at a read-only connection to enforce that at the database level
+- **Timeline view** and **image similarity** browsing
+
+### Working With Data
+
+- **Bulk operations** — tag, merge, delete, or edit metadata across many items at once
+- **Resource Reduction** — a durable workspace for collapsing repeated Resources, where clusters of repeats are proposed for review and nothing is deleted until you approve each one
+- **Group export / import** — move a Group subtree, with its resources, notes, tags, and categories, through a self-contained tar archive
+- **Download queue** — submit remote URLs, watch them in the Download Cockpit, and retry from persisted history
+- **Meta schemas** — a JSON Schema on each Category, Resource Category, or Note Type that validates metadata and generates a form for it
+- **Custom templates** — HTML fragments with server-side shortcodes, rendered into slots on detail pages, cards, hover cards, and list pages
+- **Note sharing** — publish an individual note on a separate read-only server behind an unguessable token
+- **Activity log** — create, update, delete, and plugin operations across every entity
+
+### Extending and Integrating
+
+- **Plugins** — sandboxed Lua that hooks writes, adds pages and JSON endpoints, runs background and scheduled jobs, serves its own static assets, and keeps per-plugin data in a key-value store
+- **JSON API** — every route serves both HTML and JSON (append `.json` or send `Accept: application/json`)
+- **`mr` CLI** — a command-line client covering the same API
+- **Optional accounts and RBAC** — four roles with group-subtree scoping, off by default
+
+## Requirements
+
+- **Go 1.26+**
+- **Node.js 20.19+ or 22.12+** — the range Vite 8 supports; older 20.x and 22.x releases fail `npm install` with `EBADENGINE`
+- **A C compiler** — the SQLite driver is cgo-based. Do not set `CGO_ENABLED=0`, or the binary builds without working SQLite
+
+FFmpeg (video thumbnails), LibreOffice (document thumbnails), and ImageMagick (HEIC and AVIF) are optional and detected on `PATH`.
 
 ## Quick Start
 
 ```bash
-# Build everything (CSS + JS + Go binary)
+git clone https://github.com/egeozcan/mahresources.git
+cd mahresources
+npm install
 npm run build
+```
 
-# Run in ephemeral mode (in-memory, no persistence — great for trying it out)
+`npm run build` compiles Tailwind CSS, bundles JavaScript with Vite, and builds the Go binary with the `json1` and `fts5` tags.
+
+```bash
+# Ephemeral mode: in-memory database and filesystem, nothing persists
 ./mahresources -ephemeral
 
-# Or with persistent storage
+# Persistent storage
 ./mahresources -db-type=SQLITE -db-dsn=mydb.db -file-save-path=./files
 ```
 
-See the [installation guide](https://egeozcan.github.io/mahresources/getting-started/installation) for detailed setup instructions.
+The server listens on `:8181` by default. Start it from the repository root: the binary is not self-contained and loads Pongo2 templates from `./templates` and static assets from `./public`, both relative to the working directory.
+
+No Docker image is published, but the repository builds one — see the [installation guide](https://egeozcan.github.io/mahresources/getting-started/installation) and the [Docker deployment guide](https://egeozcan.github.io/mahresources/deployment/docker).
 
 ## Configuration
+
+Settings come from environment variables (a `.env` file works) or command-line flags. Flags take precedence.
 
 | Flag | Description |
 |------|-------------|
@@ -76,56 +117,75 @@ See the [installation guide](https://egeozcan.github.io/mahresources/getting-sta
 | `-db-type` | Database type: `SQLITE` or `POSTGRES` |
 | `-db-dsn` | Database connection string |
 | `-bind-address` | Server address:port (default `:8181`) |
-| `-ephemeral` | Run fully in-memory (no persistence) |
+| `-ephemeral` | Run fully in-memory, with no persistence |
+| `-auth` | Enable user accounts and RBAC (off by default) |
+| `-plugin-path` | Directory scanned for plugins (default `./plugins`) |
+| `-share-port` | Port for the public share server (empty disables note sharing) |
 
-See the [full configuration reference](https://egeozcan.github.io/mahresources/configuration/overview) for all options including ephemeral modes, seed databases, alternative filesystems, and remote timeouts.
-
-## Testing
-
-```bash
-# Go unit tests
-go test ./...
-
-# E2E tests (starts ephemeral server automatically)
-cd e2e && npm run test:with-server
-```
-
-See `e2e/package.json` for the full set of test scripts (headed, debug, accessibility, CLI, auth and Postgres runs).
-
-## Documentation
-
-The full documentation covers everything in detail:
-
-- [Getting Started](https://egeozcan.github.io/mahresources/getting-started/installation) — Installation, first steps, quick start
-- [Concepts](https://egeozcan.github.io/mahresources/concepts/overview) — Resources, notes, groups, tags, relationships
-- [User Guide](https://egeozcan.github.io/mahresources/user-guide/navigation) — Navigation, search, bulk operations
-- [Features](https://egeozcan.github.io/mahresources/features/thumbnail-generation) — Thumbnails, versioning, plugins, saved queries
-- [Configuration](https://egeozcan.github.io/mahresources/configuration/overview) — All settings and deployment options
-- [API Reference](https://egeozcan.github.io/mahresources/api/overview) — REST API documentation
-
-**[Browse the docs](https://egeozcan.github.io/mahresources/)**
+Roughly sixty more flags cover thumbnails, hashing, timeouts, alternative filesystems, seeded ephemeral modes, and job limits. Some are editable at runtime from `/admin/settings` without a restart. See the [configuration reference](https://egeozcan.github.io/mahresources/configuration/overview).
 
 ## Security
 
-There is no built-in authentication or authorization. This application is designed to run on private networks or behind a reverse proxy that handles access control. See the [reverse proxy guide](https://egeozcan.github.io/mahresources/deployment/reverse-proxy) for setup instructions.
+Authentication is **off by default**. With `-auth` unset there is no login page and no permission checks: every request runs as an implicit administrator. That is the historical behavior, and it assumes a private, trusted network.
 
-## CLI
+> **Do not expose an unprotected instance to the internet.** For remote access, put it behind a reverse proxy that enforces authentication (nginx with basic auth, OAuth2 Proxy, Authelia). See the [reverse proxy guide](https://egeozcan.github.io/mahresources/deployment/reverse-proxy).
 
-The `mr` binary is a command-line client for the mahresources API. It covers all entity types (resources, notes, groups, tags, etc.) with CRUD operations, bulk actions, file upload/download, and version management.
+When you need accounts, turn them on with `-auth`. Requests then authenticate with a session cookie or a per-user API token, and four roles apply:
+
+- **admin** — full access, including settings, plugins, and user administration
+- **editor** — CRUD on entities, but no categories and no system settings
+- **user** — CRUD on resources and notes, optionally confined to one Group's subtree
+- **guest** — read-only, always confined to one Group's subtree
+
+Scoped users and guests are held to their subtree across lists, reads, search, MRQL, file serving, and writes. Bootstrap the first account with `-create-admin-user` and `-create-admin-password`. Built-in auth and a reverse proxy are complementary, not alternatives. See [Authentication & RBAC](https://egeozcan.github.io/mahresources/features/authentication).
+
+## The `mr` CLI
+
+`mr` is a command-line client for the HTTP API, covering every entity type with CRUD, bulk actions, file upload and download, versions, jobs, plugins, MRQL, and administration.
 
 ```bash
-# Build the CLI
-npm run build-cli
-
-# List resources
-mr resources list --content-type image/png
-
-# Upload a file
-mr resource upload photo.jpg --name "My Photo" --owner-id 1
+npm run build-cli     # produces ./mr
+make install-cli      # optional: install it onto your PATH
 ```
 
-See the [CLI documentation](https://egeozcan.github.io/mahresources/cli/) for the full command reference.
+```bash
+mr resources list --content-type image/jpeg
+mr resource upload ./photo.jpg --owner-id 3 --meta '{"camera":"Pixel"}'
+mr mrql 'type = resource AND tags = "photo" AND created > -7d'
+```
 
-## Scripting & Import
+Against a server running with `-auth`, authenticate once with `mr auth login`, or set `MR_TOKEN` to an API token. See the [CLI reference](https://egeozcan.github.io/mahresources/cli/).
 
-The HTTP API supports all CRUD operations, making it easy to script bulk imports. For an example of direct library usage, see `cmd/importExisting/main.go`. The [API documentation](https://egeozcan.github.io/mahresources/api/overview) covers all available endpoints.
+## Development
+
+```bash
+make help          # list every target
+make build         # CSS + JS bundle + Go binary
+make dev           # watch and rebuild (requires CompileDaemon)
+make test          # Go tests + frontend unit tests
+make test-e2e-all  # browser and CLI e2e suites in parallel
+make ci            # the main local CI checks
+```
+
+E2E tests run against an ephemeral server that the scripts start and stop themselves, so they never touch real data. The Playwright suite lives in `e2e/`, and includes accessibility tests (`make test-a11y`), CLI tests, and a Postgres run. `npm run build-js` must be re-run after editing anything under `src/`, and its output in `public/dist/` is committed.
+
+## Documentation
+
+- [Getting Started](https://egeozcan.github.io/mahresources/getting-started/installation) — installation, quick start, first steps
+- [Core Concepts](https://egeozcan.github.io/mahresources/concepts/overview) — resources, notes, groups, tags, relationships, series
+- [User Guide](https://egeozcan.github.io/mahresources/user-guide/navigation) — navigation, search, bulk operations
+- [Configuration](https://egeozcan.github.io/mahresources/configuration/overview) — every flag and runtime setting
+- [Advanced Features](https://egeozcan.github.io/mahresources/features/mrql) — MRQL, plugins, templates, versioning, export/import
+- [CLI Reference](https://egeozcan.github.io/mahresources/cli/) — every `mr` command
+- [API Reference](https://egeozcan.github.io/mahresources/api/overview) — REST endpoints
+- [Deployment](https://egeozcan.github.io/mahresources/deployment/docker) — Docker, systemd, reverse proxy, backups
+
+The OpenAPI spec is generated from the routes themselves with `make openapi`.
+
+## Scripting and Import
+
+Because every page has a JSON equivalent, bulk imports are ordinary HTTP scripts. `cmd/importExisting/main.go` is a worked example of driving the application context directly as a library instead.
+
+## License
+
+[GNU Affero General Public License v3.0](LICENSE).


### PR DESCRIPTION
## Summary

Completely rewrote the README to provide a clearer, more comprehensive introduction to Mahresources. The new structure emphasizes what the system does, how to get started, and where to find detailed information, rather than listing features in isolation.

## Key Changes

- **Improved opening description**: Changed from a generic tagline to a concrete explanation of what Mahresources is (self-hosted file/note storage with web UI, single Go binary, SQLite/PostgreSQL)
- **Reorganized feature documentation**: Replaced flat feature list with hierarchical sections ("What It Does", "Content", "Finding Things", "Working With Data", "Extending and Integrating") that group related capabilities
- **Added Requirements section**: Explicitly lists Go 1.26+, Node.js 20.19+/22.12+, C compiler, and optional external tools (FFmpeg, LibreOffice, ImageMagick)
- **Expanded Quick Start**: Added git clone step, clarified build process, explained that binary is not self-contained and must run from repo root
- **Enhanced Configuration section**: Added note about environment variables and `.env` file support, clarified that ~60 additional flags exist beyond the table
- **Rewrote Security section**: Moved from brief disclaimer to comprehensive coverage of default behavior (no auth), reverse proxy guidance, and detailed RBAC roles when `-auth` is enabled
- **Expanded CLI section**: Added build and install commands, example usage, and authentication guidance
- **Added Development section**: Included make targets, E2E test explanation, and note about committed JS output
- **Reorganized Documentation links**: Grouped by topic (Getting Started, Core Concepts, User Guide, etc.) with brief descriptions
- **Added Scripting and Import section**: Explains JSON API approach and references `cmd/importExisting/main.go`
- **Added License section**: References AGPL v3.0

## Notable Details

- Updated screenshot caption from "Bulk Operations" to "Timeline View" to match current UI
- Clarified that plugins can register custom note block types
- Explained MRQL as a query language with multiple access points
- Documented Resource Reduction feature for managing duplicate files
- Clarified that authentication is off by default and assumes private networks
- Emphasized that built-in auth and reverse proxy are complementary
- Noted that `npm run build-js` output is committed and must be included in diffs

https://claude.ai/code/session_01JRjoZaibxV7dbC9nAH4zQt